### PR TITLE
Guess Excel cell type basing on array cell value type

### DIFF
--- a/src/Spout/Writer/Exception/InvalidDataException.php
+++ b/src/Spout/Writer/Exception/InvalidDataException.php
@@ -2,6 +2,8 @@
 
 namespace Box\Spout\Writer\Exception;
 
+use Box\Spout\Common\Exception\SpoutException;
+
 /**
  * Class InvalidDataException
  *

--- a/src/Spout/Writer/Exception/InvalidDataException.php
+++ b/src/Spout/Writer/Exception/InvalidDataException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Box\Spout\Writer\Exception;
+
+/**
+ * Class InvalidDataException
+ *
+ * @package Box\Spout\Writer\Exception
+ */
+class InvalidDataException extends SpoutException
+{
+}

--- a/src/Spout/Writer/Internal/XLSX/Worksheet.php
+++ b/src/Spout/Writer/Internal/XLSX/Worksheet.php
@@ -3,6 +3,7 @@
 namespace Box\Spout\Writer\Internal\XLSX;
 
 use Box\Spout\Common\Exception\IOException;
+use Box\Spout\Writer\Exception\InvalidDataException;
 use Box\Spout\Writer\Helper\XLSX\CellHelper;
 
 /**
@@ -119,6 +120,7 @@ EOD;
      *          Example $dataRow = ['data1', 1234, null, '', 'data5'];
      * @return void
      * @throws \Box\Spout\Common\Exception\IOException If the data cannot be written
+     * @throws \Box\Spout\Writer\Exception\InvalidDataException If input data are of invalid type
      */
     public function addRow($dataRow)
     {
@@ -132,19 +134,27 @@ EOD;
             $columnIndex = CellHelper::getCellIndexFromColumnIndex($cellNumber);
             $data .= '            <c r="' . $columnIndex . $rowIndex . '"';
 
-            if (empty($cellValue)) {
-                $data .= '/>' . PHP_EOL;
-            } else {
-                if (is_numeric($cellValue)) {
+            switch(true) {
+                case empty($cellValue):
+                    $data .= '/>' . PHP_EOL;
+                    break;
+                case gettype($cellValue) === 'integer':
+                case gettype($cellValue) === 'boolean':
+                case gettype($cellValue) === 'float':
                     $data .= '><v>' . $cellValue . '</v></c>' . PHP_EOL;
-                } else {
+                    break;
+                case gettype($cellValue) === 'object' && method_exists($cellValue, '__toString'):
+                    $cellValue = (string)$cellValue;
+                case gettype($cellValue) === 'string':
                     if ($this->shouldUseInlineStrings) {
                         $data .= ' t="inlineStr"><is><t>' . $this->stringsEscaper->escape($cellValue) . '</t></is></c>' . PHP_EOL;
                     } else {
                         $sharedStringId = $this->sharedStringsHelper->writeString($cellValue);
                         $data .= ' t="s"><v>' . $sharedStringId . '</v></c>' . PHP_EOL;
                     }
-                }
+                    break;
+                default:
+                    throw new InvalidDataException("Invalid data type " . gettype($cellValue));
             }
 
             $cellNumber++;

--- a/src/Spout/Writer/Internal/XLSX/Worksheet.php
+++ b/src/Spout/Writer/Internal/XLSX/Worksheet.php
@@ -135,9 +135,6 @@ EOD;
             $data .= '            <c r="' . $columnIndex . $rowIndex . '"';
 
             switch(true) {
-                case empty($cellValue):
-                    $data .= '/>' . PHP_EOL;
-                    break;
                 case gettype($cellValue) === 'integer':
                 case gettype($cellValue) === 'boolean':
                 case gettype($cellValue) === 'float':
@@ -153,6 +150,9 @@ EOD;
                         $sharedStringId = $this->sharedStringsHelper->writeString($cellValue);
                         $data .= ' t="s"><v>' . $sharedStringId . '</v></c>' . PHP_EOL;
                     }
+                    break;
+                case empty($cellValue):
+                    $data .= '/>' . PHP_EOL;
                     break;
                 default:
                     throw new InvalidDataException("Invalid data type " . gettype($cellValue));

--- a/src/Spout/Writer/Internal/XLSX/Worksheet.php
+++ b/src/Spout/Writer/Internal/XLSX/Worksheet.php
@@ -141,6 +141,7 @@ EOD;
                 case gettype($cellValue) === 'integer':
                 case gettype($cellValue) === 'boolean':
                 case gettype($cellValue) === 'float':
+                case gettype($cellValue) === 'double':
                     $data .= '><v>' . $cellValue . '</v></c>' . PHP_EOL;
                     break;
                 case gettype($cellValue) === 'object' && method_exists($cellValue, '__toString'):


### PR DESCRIPTION
Hello, 

writing to Excel files creates some problem on larger integers - this patch is guessing proper cell type basing on data, while currently used is_numeric() was causing writing large integers into output file disregarding variable type.

This patch can in some cases break compatibility for some scripts - perhaps it should be wrapped in conditional expression based on some parameter, allowing to revert to current behavior, yet I'm really bad at inventing parameter names.

Regards,
Grzegorz