### PR TITLE
Fix DIRECTORY_SEPARATOR bug occurring on Windows

### DIFF
--- a/src/Spout/Reader/Internal/XLSX/Worksheet.php
+++ b/src/Spout/Reader/Internal/XLSX/Worksheet.php
@@ -31,7 +31,7 @@ class Worksheet
      */
     public function getDataXmlFilePath()
     {
-        return ltrim($this->dataXmlFilePath, DIRECTORY_SEPARATOR);
+        return ltrim($this->dataXmlFilePath, '/');
     }
 
     /**


### PR DESCRIPTION
Fixes #3:
The sheetN.xml files location is dynamically retrieved when parsing `[Content_Types].xml`. In this file, the location is like `/xl/worksheets/sheet1.xml`.

Because the zip stream wrapper expects the zip entry name to be like `xl/worksheets/sheet1/xml` (without the first `/`), this first `/` needs to be trimmed. It was trimmed using: `ltrim($this->dataXmlFilePath, DIRECTORY_SEPARATOR);`
which obvisously does not work on Windows platform where `DIRECTORY_SEPARATOR is` `\`.
Replacing `DIRECTORY_SEPARATOR` by `/` solves this issue.