### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "box/spout",
     "description": "PHP Library to read and write CSV and XLSX files, in a fast and scalable way",
     "type": "library",
-    "version": "1.0.9",
     "keywords": ["php","read","write","csv","xlsx","excel","spreadsheet","scale","memory","stream","ooxml"],
     "license": "Apache-2.0",
     "homepage": "https://www.github.com/box/spout",


### PR DESCRIPTION
As mentionned here, version in composer.json can be omitted and only managed through git versioning: https://github.com/box/spout/pull/44#issuecomment-107912203