### PR TITLE
Prevent entity loading when reading XML

### DIFF
--- a/src/Spout/Reader/Helper/XLSX/SharedStringsHelper.php
+++ b/src/Spout/Reader/Helper/XLSX/SharedStringsHelper.php
@@ -112,7 +112,7 @@ class SharedStringsHelper
         $escaper = new \Box\Spout\Common\Escaper\XLSX();
 
         $sharedStringsFilePath = $this->getSharedStringsFilePath();
-        if ($xmlReader->open($sharedStringsFilePath, null, LIBXML_NONET) === false) {
+        if ($xmlReader->open($sharedStringsFilePath, null, LIBXML_NOENT|LIBXML_NONET) === false) {
             throw new IOException('Could not open "' . self::SHARED_STRINGS_XML_FILE_PATH . '".');
         }
 

--- a/src/Spout/Reader/XLSX.php
+++ b/src/Spout/Reader/XLSX.php
@@ -158,7 +158,7 @@ class XLSX extends AbstractReader
         $worksheetDataXMLFilePath = $worksheet->getDataXmlFilePath();
 
         $worksheetDataFilePath = 'zip://' . $this->filePath . '#' . $worksheetDataXMLFilePath;
-        if ($this->xmlReader->open($worksheetDataFilePath, null, LIBXML_NONET) === false) {
+        if ($this->xmlReader->open($worksheetDataFilePath, null, LIBXML_NOENT|LIBXML_NONET) === false) {
             throw new IOException('Could not open "' . $worksheetDataXMLFilePath . '".');
         }
     }

--- a/tests/Spout/Reader/XLSXTest.php
+++ b/tests/Spout/Reader/XLSXTest.php
@@ -250,7 +250,7 @@ class XLSXTest extends \PHPUnit_Framework_TestCase
     {
         $allRows = $this->getAllRowsForFile('billion_laughs_test_file.xlsx');
 
-        $expectedMaxMemoryUsage = 20 * 1024 * 1024; // 20MB
+        $expectedMaxMemoryUsage = 30 * 1024 * 1024; // 30MB
         $this->assertLessThan($expectedMaxMemoryUsage, memory_get_peak_usage(true), 'Entities should not be expanded and therefore consume all the memory.');
 
         $expectedFirstRow = ['s1--A1', 's1--B1', 's1--C1', 's1--D1', 's1--E1'];


### PR DESCRIPTION
Fixes #57 

Added LIBXML_NOENT option when reading a XML file
libxml_disable_entity_loader(true) cannot be used because it disables the use of XMLReader::open()... see https://bugs.php.net/bug.php?id=62577