### PR TITLE
Use Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 7.0
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
This is to avoid re-downloading all dependencies for every build.