### PR TITLE
Use number-columns-repeated in ODS writer

### DIFF
--- a/src/Spout/Writer/Common/Internal/AbstractWorkbook.php
+++ b/src/Spout/Writer/Common/Internal/AbstractWorkbook.php
@@ -135,7 +135,7 @@ abstract class AbstractWorkbook implements WorkbookInterface
      * If shouldCreateNewSheetsAutomatically option is set to true, it will handle pagination
      * with the creation of new worksheets if one worksheet has reached its maximum capicity.
      *
-     * @param array $dataRow Array containing data to be written.
+     * @param array $dataRow Array containing data to be written. Cannot be empty.
      *          Example $dataRow = ['data1', 1234, null, '', 'data5'];
      * @param \Box\Spout\Writer\Style\Style $style Style to be applied to the row.
      * @return void

--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -118,7 +118,7 @@ EOD;
     /**
      * Adds data to the worksheet.
      *
-     * @param array $dataRow Array containing data to be written.
+     * @param array $dataRow Array containing data to be written. Cannot be empty.
      *          Example $dataRow = ['data1', 1234, null, '', 'data5'];
      * @param \Box\Spout\Writer\Style\Style $style Style to be applied to the row. NULL means use default style.
      * @return void


### PR DESCRIPTION
The number-columns-repeated usage may reduce the size of the outputted XML file by merging repeated values together.