### PR TITLE
Increase entropy of uniqid

### DIFF
--- a/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
@@ -94,7 +94,7 @@ class FileSystemHelper extends \Box\Spout\Common\Helper\FileSystemHelper
      */
     protected function createRootFolder()
     {
-        $this->rootFolder = $this->createFolder($this->baseFolderPath, uniqid('xlsx'));
+        $this->rootFolder = $this->createFolder($this->baseFolderPath, uniqid('xlsx', true));
         return $this;
     }
 


### PR DESCRIPTION
This is to avoid conflicts if two folders are being created at the exact same time.