### PR TITLE
Proper mime type detection for XLSX files

### DIFF
--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -386,6 +386,21 @@ class WriterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGeneratedFileShouldHaveTheCorrectMimeType()
+    {
+        $fileName = 'test_mime_type.xlsx';
+        $resourcePath = $this->getGeneratedResourcePath($fileName);
+        $dataRows = [['foo']];
+
+        $this->writeToXLSXFile($dataRows, $fileName);
+
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $this->assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $finfo->file($resourcePath));
+    }
+
+    /**
      * @param array $allRows
      * @param string $fileName
      * @param bool $shouldUseInlineStrings


### PR DESCRIPTION
Fixes #149 

Heuristics to detect proper mime type for XLSX files expect to see certain files at the beginning of the XLSX archive. The order in which the XML files are added therefore matters.
Specifically, "[Content_Types].xml" should be added first, followed by the files located in the "xl" folder (at least 1 file).