### PR TITLE
Improve ZIP interface for better mime detection

### DIFF
--- a/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
@@ -353,10 +353,19 @@ EOD;
      */
     public function zipRootFolderAndCopyToStream($streamPointer)
     {
-        $zipHelper = new ZipHelper();
-        $zipHelper->zipFolderAndCopyToStream($this->rootFolder, $streamPointer);
+        $zipHelper = new ZipHelper($this->rootFolder);
+
+        // In order to have the file's mime type detected properly, files need to be added
+        // to the zip file in a particular order.
+        // "[Content_Types].xml" then at least 2 files located in "xl" folder should be zipped first.
+        $zipHelper->addFileToArchive($this->rootFolder, self::CONTENT_TYPES_XML_FILE_NAME);
+        $zipHelper->addFileToArchive($this->rootFolder, self::XL_FOLDER_NAME . '/' . self::WORKBOOK_XML_FILE_NAME);
+        $zipHelper->addFileToArchive($this->rootFolder, self::XL_FOLDER_NAME . '/' . self::STYLES_XML_FILE_NAME);
+
+        $zipHelper->addFolderToArchive($this->rootFolder, ZipHelper::EXISTING_FILES_SKIP);
+        $zipHelper->closeArchiveAndCopyToStream($streamPointer);
 
         // once the zip is copied, remove it
-        $this->deleteFile($zipHelper->getZipFilePath($this->rootFolder));
+        $this->deleteFile($zipHelper->getZipFilePath());
     }
 }

--- a/tests/Spout/Writer/ODS/WriterTest.php
+++ b/tests/Spout/Writer/ODS/WriterTest.php
@@ -5,6 +5,7 @@ namespace Box\Spout\Writer\ODS;
 use Box\Spout\Common\Type;
 use Box\Spout\Reader\Wrapper\XMLReader;
 use Box\Spout\TestUsingResource;
+use Box\Spout\Writer\Common\Helper\ZipHelper;
 use Box\Spout\Writer\WriterFactory;
 
 /**
@@ -366,6 +367,30 @@ class WriterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertValueWasWrittenToSheet($fileName, 1, 'I have');
         $this->assertValueWasWrittenToSheet($fileName, 1, 'a dream');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGeneratedFileShouldHaveTheCorrectMimeType()
+    {
+        // Only PHP7+ gives the correct mime type since it requires adding
+        // uncompressed files to the final archive (which support was added in PHP7)
+        if (!ZipHelper::canChooseCompressionMethod()) {
+            $this->markTestSkipped(
+                'The PHP version used does not support setting the compression method of archived files,
+                resulting in the mime type to be detected incorrectly.'
+            );
+        }
+
+        $fileName = 'test_mime_type.ods';
+        $resourcePath = $this->getGeneratedResourcePath($fileName);
+        $dataRow = ['foo'];
+
+        $this->writeToODSFile([$dataRow], $fileName);
+
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $this->assertEquals('application/vnd.oasis.opendocument.spreadsheet', $finfo->file($resourcePath));
     }
 
     /**


### PR DESCRIPTION
The ZipHelper interface is now more generic and allow single files to be added.
It supports adding uncompressed files (for PHP7+), which is required to have the mime detection magic work with ODS files.
Also fixed a few issues with the created ODS file (thanks to https://odf-validator.rhcloud.com/)