### PR TITLE
Fixing the boolean bug.

### DIFF
--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -146,7 +146,11 @@ EOD;
                     $cellXML .= ' t="s"><v>' . $sharedStringId . '</v></c>';
                 }
             } else if (CellHelper::isBoolean($cellValue)) {
-                $cellXML .= ' t="b"><v>' . $cellValue . '</v></c>';
+                if ($cellValue === true) {
+                    $cellXML .= ' t="b"><v>1</v></c>';
+                } else {
+                    $cellXML .= ' t="b"><v>0</v></c>';
+                }
             } else if (CellHelper::isNumeric($cellValue)) {
                 $cellXML .= '><v>' . $cellValue . '</v></c>';
             } else if (empty($cellValue)) {

--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -146,11 +146,7 @@ EOD;
                     $cellXML .= ' t="s"><v>' . $sharedStringId . '</v></c>';
                 }
             } else if (CellHelper::isBoolean($cellValue)) {
-                if ($cellValue === true) {
-                    $cellXML .= ' t="b"><v>1</v></c>';
-                } else {
-                    $cellXML .= ' t="b"><v>0</v></c>';
-                }
+                    $cellXML .= ' t="b"><v>' . intval($cellValue) . '</v></c>';
             } else if (CellHelper::isNumeric($cellValue)) {
                 $cellXML .= '><v>' . $cellValue . '</v></c>';
             } else if (empty($cellValue)) {


### PR DESCRIPTION
Before this coomit, if you add a `false` value, the cell in the Excel document is empty, because generated string is the following:

```
<c r="B1" s="0" t="b"><v></v></c>
```

But, with this fix, the string is the following:

```
<c r="B1" s="0" t="b"><v>0</v></c>
```

So, the `false` value is generated propperly and it's not being confused with the `null` value generation.