### PR TITLE
PhpStorm autocompletion compatibility.

### DIFF
--- a/src/Spout/Writer/WriterFactory.php
+++ b/src/Spout/Writer/WriterFactory.php
@@ -20,7 +20,7 @@ class WriterFactory
      *
      * @api
      * @param  string $writerType Type of the writer to instantiate
-     * @return WriterInterface
+     * @return CSV\Writer | XLSX\Writer | ODS\Writer
      * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
      */
     public static function create($writerType)


### PR DESCRIPTION
If the documentation comment specifies that a `WriterInterface` is returned, PhpStorm can't recognize that there's a `setTempFolder` method. But with this fix, it recognizes all the available methods `Writer` classes have. And, in my opinion, the documentation comment is more correct.