### PR TITLE
Fix line breaks on CSV reader

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -292,35 +292,6 @@ class GlobalFunctionsHelper
     }
 
     /**
-     * Wrapper around global function stream_get_line()
-     * @see stream_get_line()
-     *
-     * @param resource $handle
-     * @param int $length
-     * @param string|void $ending
-     * @return string|bool
-     */
-    public function stream_get_line($handle, $length, $ending = null)
-    {
-        return stream_get_line($handle, $length, $ending);
-    }
-
-    /**
-     * Wrapper around global function str_getcsv()
-     * @see str_getcsv()
-     *
-     * @param string $input
-     * @param string|void $delimiter
-     * @param string|void $enclosure
-     * @param string|void $escape
-     * @return array
-     */
-    public function str_getcsv($input, $delimiter = null, $enclosure = null, $escape = null)
-    {
-        return str_getcsv($input, $delimiter, $enclosure, $escape);
-    }
-
-    /**
      * Wrapper around global function function_exists()
      * @see function_exists()
      *

--- a/src/Spout/Reader/CSV/Reader.php
+++ b/src/Spout/Reader/CSV/Reader.php
@@ -32,6 +32,9 @@ class Reader extends AbstractReader
     /** @var string Defines the End of line */
     protected $endOfLineCharacter = "\n";
 
+    /** @var string */
+    protected $autoDetectLineEndings;
+
     /**
      * Sets the field delimiter for the CSV.
      * Needs to be called before opening the reader.
@@ -104,6 +107,9 @@ class Reader extends AbstractReader
      */
     protected function openReader($filePath)
     {
+        $this->autoDetectLineEndings = ini_get('auto_detect_line_endings');
+        ini_set('auto_detect_line_endings', '1');
+
         $this->filePointer = $this->globalFunctionsHelper->fopen($filePath, 'r');
         if (!$this->filePointer) {
             throw new IOException("Could not open file $filePath for reading.");
@@ -140,5 +146,7 @@ class Reader extends AbstractReader
         if ($this->filePointer) {
             $this->globalFunctionsHelper->fclose($this->filePointer);
         }
+
+        ini_set('auto_detect_line_endings', $this->autoDetectLineEndings);
     }
 }

--- a/tests/Spout/Reader/CSV/ReaderTest.php
+++ b/tests/Spout/Reader/CSV/ReaderTest.php
@@ -205,6 +205,15 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testReadShouldNotTruncateLineBreak()
+    {
+        $allRows = $this->getAllRowsForFile('csv_with_line_breaks.csv', ',');
+        $this->assertEquals("This is,\na comma", $allRows[0][0]);
+    }
+
+    /**
      * @return array
      */
     public function dataProviderForTestReadShouldSkipBom()

--- a/tests/resources/csv/csv_with_line_breaks.csv
+++ b/tests/resources/csv/csv_with_line_breaks.csv
@@ -1,0 +1,2 @@
+"This is,
+a comma",csv--12


### PR DESCRIPTION
Fix CSV reader to allow line breaks in CSV files.

The only way founded is to use `fgetcsv()` and fix manually the problem with non UTF-8 data.
If principle is validated, I will remove useless property `endOfLineCharacter` because with fgetcsv(), we cannot define end of line parameter. 

related issue: #183 