### PR TITLE
Custom stream wrapper support

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -281,6 +281,17 @@ class GlobalFunctionsHelper
     }
 
     /**
+     * Wrapper around global function stream_get_wrappers()
+     * @see stream_get_wrappers()
+     *
+     * @return array
+     */
+    public function stream_get_wrappers()
+    {
+        return stream_get_wrappers();
+    }
+
+    /**
      * Wrapper around global function stream_get_line()
      * @see stream_get_line()
      *

--- a/src/Spout/Reader/CSV/Reader.php
+++ b/src/Spout/Reader/CSV/Reader.php
@@ -30,7 +30,7 @@ class Reader extends AbstractReader
     protected $encoding = EncodingHelper::ENCODING_UTF8;
 
     /** @var string Defines the End of line */
-    protected $endOfLineCharacter = "\n";    
+    protected $endOfLineCharacter = "\n";
 
     /**
      * Sets the field delimiter for the CSV.
@@ -82,7 +82,17 @@ class Reader extends AbstractReader
     {
         $this->endOfLineCharacter = $endOfLineCharacter;
         return $this;
-    }  
+    }
+
+    /**
+     * Returns whether stream wrappers are supported
+     *
+     * @return bool
+     */
+    protected function doesSupportStreamWrapper()
+    {
+        return true;
+    }
 
     /**
      * Opens the file at the given path to make it ready to be read.

--- a/src/Spout/Reader/ODS/Reader.php
+++ b/src/Spout/Reader/ODS/Reader.php
@@ -20,6 +20,16 @@ class Reader extends AbstractReader
     protected $sheetIterator;
 
     /**
+     * Returns whether stream wrappers are supported
+     *
+     * @return bool
+     */
+    protected function doesSupportStreamWrapper()
+    {
+        return false;
+    }
+
+    /**
      * Opens the file at the given file path to make it ready to be read.
      *
      * @param  string $filePath Path of the file to be read

--- a/src/Spout/Reader/XLSX/Reader.php
+++ b/src/Spout/Reader/XLSX/Reader.php
@@ -38,6 +38,16 @@ class Reader extends AbstractReader
     }
 
     /**
+     * Returns whether stream wrappers are supported
+     *
+     * @return bool
+     */
+    protected function doesSupportStreamWrapper()
+    {
+        return false;
+    }
+
+    /**
      * Opens the file at the given file path to make it ready to be read.
      * It also parses the sharedStrings.xml file to get all the shared strings available in memory
      * and fetches all the available sheets.

--- a/tests/Spout/Reader/CSV/ReaderTest.php
+++ b/tests/Spout/Reader/CSV/ReaderTest.php
@@ -423,4 +423,50 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedRows, $allRows);
     }
 
+    /**
+     * @return void
+     */
+    public function testReadCustomStreamWrapper()
+    {
+        $allRows = [];
+        $resourcePath = 'spout://csv_standard';
+
+        // register stream wrapper
+        stream_wrapper_register('spout', SpoutTestStream::CLASS_NAME);
+
+        /** @var \Box\Spout\Reader\CSV\Reader $reader */
+        $reader = ReaderFactory::create(Type::CSV);
+        $reader->open($resourcePath);
+
+        foreach ($reader->getSheetIterator() as $sheet) {
+            foreach ($sheet->getRowIterator() as $row) {
+                $allRows[] = $row;
+            }
+        }
+
+        $reader->close();
+
+        $expectedRows = [
+            ['csv--11', 'csv--12', 'csv--13'],
+            ['csv--21', 'csv--22', 'csv--23'],
+            ['csv--31', 'csv--32', 'csv--33'],
+        ];
+        $this->assertEquals($expectedRows, $allRows);
+
+        // cleanup
+        stream_wrapper_unregister('spout');
+    }
+
+    /**
+     * @expectedException \Box\Spout\Common\Exception\IOException
+     *
+     * @return void
+     */
+    public function testReadWithUnsupportedCustomStreamWrapper()
+    {
+        /** @var \Box\Spout\Reader\CSV\Reader $reader */
+        $reader = ReaderFactory::create(Type::CSV);
+        $reader->open('unsupported://foobar');
+    }
+
 }

--- a/tests/Spout/Reader/CSV/SpoutTestStream.php
+++ b/tests/Spout/Reader/CSV/SpoutTestStream.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Box\Spout\Reader\CSV;
+
+/**
+ * Class SpoutTestStream
+ * Custom stream that reads CSV files located in the tests/resources/csv folder.
+ * For example: spout://foobar will point to tests/resources/csv/foobar.csv
+ *
+ * @package Box\Spout\Reader\CSV
+ */
+class SpoutTestStream
+{
+    const CLASS_NAME = __CLASS__;
+
+    const PATH_TO_CSV_RESOURCES = 'tests/resources/csv/';
+    const CSV_EXTENSION = '.csv';
+
+    /** @var int $position */
+    private $position;
+
+    /** @var resource $fileHandle */
+    private $fileHandle;
+
+    /**
+     * @param string $path
+     * @param int $flag
+     * @return array
+     */
+    public function url_stat($path, $flag)
+    {
+        $filePath = $this->getFilePathFromStreamPath($path);
+        return stat($filePath);
+    }
+
+    /**
+     * @param string $streamPath
+     * @return string
+     */
+    private function getFilePathFromStreamPath($streamPath)
+    {
+        $fileName = parse_url($streamPath, PHP_URL_HOST);
+        return self::PATH_TO_CSV_RESOURCES . $fileName . self::CSV_EXTENSION;
+    }
+
+    /**
+     * @param string $path
+     * @param string $mode
+     * @param int $options
+     * @param string $opened_path
+     * @return bool
+     */
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        $this->position = 0;
+
+        // the path is like "spout://csv_name" so the actual file name correspond the name of the host.
+        $filePath = $this->getFilePathFromStreamPath($path);
+        $this->fileHandle = fopen($filePath, $mode);
+
+        return true;
+    }
+
+    /**
+     * @param int $numBytes
+     * @return string
+     */
+    public function stream_read($numBytes)
+    {
+        $this->position += $numBytes;
+        return fread($this->fileHandle, $numBytes);
+    }
+
+    /**
+     * @return int
+     */
+    public function stream_tell()
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int $offset
+     * @param int|void $whence
+     * @return bool
+     */
+    public function stream_seek($offset, $whence = SEEK_SET)
+    {
+        $result = fseek($this->fileHandle, $offset, $whence);
+        if ($result === -1) {
+            return false;
+        }
+
+        if ($whence === SEEK_SET) {
+            $this->position = $offset;
+        } else if ($whence === SEEK_CUR) {
+            $this->position += $offset;
+        } else {
+            // not implemented
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function stream_close()
+    {
+        return fclose($this->fileHandle);
+    }
+
+    /**
+     * @return bool
+     */
+    public function stream_eof()
+    {
+        return feof($this->fileHandle);
+    }
+}

--- a/tests/Spout/Reader/ODS/ReaderTest.php
+++ b/tests/Spout/Reader/ODS/ReaderTest.php
@@ -364,6 +364,30 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Box\Spout\Common\Exception\IOException
+     *
+     * @return void
+     */
+    public function testReadWithUnsupportedCustomStreamWrapper()
+    {
+        /** @var \Box\Spout\Reader\ODS\Reader $reader */
+        $reader = ReaderFactory::create(Type::ODS);
+        $reader->open('unsupported://foobar');
+    }
+
+    /**
+     * @expectedException \Box\Spout\Common\Exception\IOException
+     *
+     * @return void
+     */
+    public function testReadWithSupportedCustomStreamWrapper()
+    {
+        /** @var \Box\Spout\Reader\ODS\Reader $reader */
+        $reader = ReaderFactory::create(Type::ODS);
+        $reader->open('php://memory');
+    }
+
+    /**
      * @param string $fileName
      * @return array All the read rows the given file
      */

--- a/tests/Spout/Reader/XLSX/ReaderTest.php
+++ b/tests/Spout/Reader/XLSX/ReaderTest.php
@@ -405,6 +405,30 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Box\Spout\Common\Exception\IOException
+     *
+     * @return void
+     */
+    public function testReadWithUnsupportedCustomStreamWrapper()
+    {
+        /** @var \Box\Spout\Reader\XLSX\Reader $reader */
+        $reader = ReaderFactory::create(Type::XLSX);
+        $reader->open('unsupported://foobar');
+    }
+
+    /**
+     * @expectedException \Box\Spout\Common\Exception\IOException
+     *
+     * @return void
+     */
+    public function testReadWithSupportedCustomStreamWrapper()
+    {
+        /** @var \Box\Spout\Reader\XLSX\Reader $reader */
+        $reader = ReaderFactory::create(Type::XLSX);
+        $reader->open('php://memory');
+    }
+
+    /**
      * @param string $fileName
      * @return array All the read rows the given file
      */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,7 @@ require_once(dirname(__DIR__) . '/vendor/autoload.php');
 
 require_once(dirname(__DIR__) . '/tests/Spout/TestUsingResource.php');
 require_once(dirname(__DIR__) . '/tests/Spout/ReflectionHelper.php');
+require_once(dirname(__DIR__) . '/tests/Spout/Reader/CSV/SpoutTestStream.php');
 
 // Make sure a timezone is set to be able to work with dates
 date_default_timezone_set('UTC');


### PR DESCRIPTION
Fixes #176

Added support for custom stream wrappers, such as "fly" or "s3".
Support is determined per reader.