### PR TITLE
Check file handle is valid before manipulating it

### DIFF
--- a/src/Spout/Writer/ODS/Internal/Worksheet.php
+++ b/src/Spout/Writer/ODS/Internal/Worksheet.php
@@ -218,6 +218,10 @@ class Worksheet implements WorksheetInterface
      */
     public function close()
     {
+        if (!is_resource($this->sheetFilePointer)) {
+            return;
+        }
+
         fclose($this->sheetFilePointer);
     }
 }

--- a/src/Spout/Writer/XLSX/Helper/SharedStringsHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/SharedStringsHelper.php
@@ -88,6 +88,10 @@ EOD;
      */
     public function close()
     {
+        if (!is_resource($this->sharedStringsFilePointer)) {
+            return;
+        }
+
         fwrite($this->sharedStringsFilePointer, '</sst>');
 
         // Replace the default strings count with the actual number of shared strings in the file header

--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -178,6 +178,10 @@ EOD;
      */
     public function close()
     {
+        if (!is_resource($this->sheetFilePointer)) {
+            return;
+        }
+
         fwrite($this->sheetFilePointer, '</sheetData>');
         fwrite($this->sheetFilePointer, '</worksheet>');
         fclose($this->sheetFilePointer);


### PR DESCRIPTION
This fixes issues when something went wrong on reader/writer init and the developer wants to close the reader/writer.
The file handle may not be defined so we need to add a check for it, before actually using it.