### PR TITLE
Add background-color to styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $writer->setShouldAddBOM(false);
 
 #### Row styling
 
-It is possible to apply some formatting options to a row. Spout supports fonts, borders as well as alignment styles.
+It is possible to apply some formatting options to a row. Spout supports fonts, background, borders as well as alignment styles.
 
 ```php
 use Box\Spout\Common\Type;
@@ -146,6 +146,7 @@ $style = (new StyleBuilder())
            ->setFontSize(15)
            ->setFontColor(Color::BLUE)
            ->setShouldWrapText()
+           ->setBackgroundColor(Color::YELLOW)
            ->build();
 
 $writer = WriterFactory::create(Type::XLSX);

--- a/src/Spout/Writer/ODS/Helper/StyleHelper.php
+++ b/src/Spout/Writer/ODS/Helper/StyleHelper.php
@@ -265,6 +265,11 @@ EOD;
             $content .= sprintf($borderProperty, implode(' ', $borders));
         }
 
+        if ($style->shouldApplyBackgroundColor()) {
+            $content .= sprintf('
+                <style:table-cell-properties fo:background-color="#%s"/>', $style->getBackgroundColor());
+        }
+
         $content .= '</style:style>';
 
         return $content;

--- a/src/Spout/Writer/Style/Style.php
+++ b/src/Spout/Writer/Style/Style.php
@@ -71,6 +71,13 @@ class Style
      */
     protected $shouldApplyBorder = false;
 
+    /** @var string Background color */
+    protected $backgroundColor = null;
+
+    /** @var bool */
+    protected $hasSetBackgroundColor = false;
+
+
     /**
      * @return int|null
      */
@@ -280,6 +287,35 @@ class Style
     }
 
     /**
+     * Sets the background color
+     * @param $color ARGB color (@see Color)
+     * @return Style
+     */
+    public function setBackgroundColor($color)
+    {
+        $this->hasSetBackgroundColor = true;
+        $this->backgroundColor = $color;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBackgroundColor()
+    {
+        return $this->backgroundColor;
+    }
+
+    /**
+     *
+     * @return bool Whether the background color should be applied
+     */
+    public function shouldApplyBackgroundColor()
+    {
+        return $this->hasSetBackgroundColor;
+    }
+
+    /**
      * Serializes the style for future comparison with other styles.
      * The ID is excluded from the comparison, as we only care about
      * actual style properties.
@@ -340,6 +376,9 @@ class Style
         }
         if (!$this->getBorder() && $baseStyle->shouldApplyBorder()) {
             $mergedStyle->setBorder($baseStyle->getBorder());
+        }
+        if (!$this->hasSetBackgroundColor && $baseStyle->shouldApplyBackgroundColor()) {
+            $mergedStyle->setBackgroundColor($baseStyle->getBackgroundColor());
         }
 
         return $mergedStyle;

--- a/src/Spout/Writer/Style/StyleBuilder.php
+++ b/src/Spout/Writer/Style/StyleBuilder.php
@@ -134,6 +134,19 @@ class StyleBuilder
     }
 
     /**
+     *  Sets a background color
+     *
+     * @api
+     * @param string $color ARGB color (@see Color)
+     * @return StyleBuilder 
+     */
+    public function setBackgroundColor($color)
+    {
+        $this->style->setBackgroundColor($color);
+        return $this;
+    }
+
+    /**
      * Returns the configured style. The style is cached and can be reused.
      *
      * @api

--- a/tests/Spout/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/ODS/WriterWithStyleTest.php
@@ -118,6 +118,7 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
             ->setFontSize(15)
             ->setFontColor(Color::RED)
             ->setFontName('Cambria')
+            ->setBackgroundColor(Color::GREEN)
             ->build();
 
         $this->writeToODSFileWithMultipleStyles($dataRows, $fileName, [$style, $style2]);
@@ -137,6 +138,7 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
         $this->assertFirstChildHasAttributeEquals('15pt', $customFont2Element, 'text-properties', 'fo:font-size');
         $this->assertFirstChildHasAttributeEquals('#' . Color::RED, $customFont2Element, 'text-properties', 'fo:color');
         $this->assertFirstChildHasAttributeEquals('Cambria', $customFont2Element, 'text-properties', 'style:font-name');
+        $this->assertFirstChildHasAttributeEquals('#' . Color::GREEN, $customFont2Element, 'table-cell-properties', 'fo:background-color');
     }
 
     /**
@@ -237,6 +239,26 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
 
         $customStyleElement = $styleElements[1];
         $this->assertFirstChildHasAttributeEquals('wrap', $customStyleElement, 'table-cell-properties', 'fo:wrap-option');
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddBackgroundColor()
+    {
+        $fileName = 'test_default_background_style.ods';
+        $dataRows = [
+            ['defaultBgColor'],
+        ];
+
+        $style = (new StyleBuilder())->setBackgroundColor(Color::WHITE)->build();
+        $this->writeToODSFile($dataRows, $fileName, $style);
+
+        $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
+        $this->assertEquals(2, count($styleElements), 'There should be 2 styles (default and custom)');
+
+        $customStyleElement = $styleElements[1];
+        $this->assertFirstChildHasAttributeEquals('#' . Color::WHITE, $customStyleElement, 'table-cell-properties', 'fo:background-color');
     }
 
     /**

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -126,7 +126,6 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
 
         $fontElements = $fontsDomElement->getElementsByTagName('font');
         $this->assertEquals(3, $fontElements->length, 'There should be 3 associated "font" elements, including the default one.');
-
         // First font should be the default one
         $defaultFontElement = $fontElements->item(0);
         $this->assertChildrenNumEquals(3, $defaultFontElement, 'The default font should only have 3 properties.');
@@ -232,6 +231,34 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
         $xfElement = $cellXfsDomElement->getElementsByTagName('xf')->item(1);
         $this->assertEquals(1, $xfElement->getAttribute('applyAlignment'));
         $this->assertFirstChildHasAttributeEquals('1', $xfElement, 'alignment', 'wrapText');
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddBackgroundColor()
+    {
+        $fileName = 'test_add_background_color.xlsx';
+        $dataRows = [
+            ["BgColor"],
+        ];
+        $style = (new StyleBuilder())->setBackgroundColor(Color::WHITE)->build();
+        $this->writeToXLSXFile($dataRows, $fileName, $style);
+        $fillsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'fills');
+        $this->assertEquals(3, $fillsDomElement->getAttribute('count'), 'There should be 3 fills, including the 2 default ones');
+
+        $fillsElements = $fillsDomElement->getElementsByTagName('fill');
+
+        $thirdFillElement = $fillsElements->item(2); // Zero based
+        $fgColor = $thirdFillElement->getElementsByTagName('fgColor')->item(0)->getAttribute('rgb');
+
+        $this->assertEquals(Color::WHITE, $fgColor, 'The foreground color should equal white');
+
+        $styleXfsElements = $this->getXmlSectionFromStylesXmlFile($fileName, 'cellXfs');
+        $this->assertEquals(2, $styleXfsElements->getAttribute('count'), '2 cell xfs present - a default one and a custom one');
+
+        $customFillId = $styleXfsElements->lastChild->getAttribute('fillId');
+        $this->assertEquals(2, (int)$customFillId, 'The custom fill id should have the index 2');
     }
 
     /**


### PR DESCRIPTION
This is loosely related to #182. This PR introduces setting a background color to the styles definition. 

* For xlsx and ods.
* Only "solid" backgrounds are supported. XLSX supports a whole array of ```patternType``` constants (http://www.officeopenxml.com/SSstyles.php, darkGrid, lightTrellis) - these are ignored.
* XLSX knows a bgColor element (The color to use for the background of the fill when the type is not solid.) and a fgColor element (The color to use for the the background in solid fills.) - these are just treated as the same. Only a sick, twisted minded MS Office Interop Developer knows why a background color in solid fills is a foreColor. (I am kidding of course).
* Some Tests



