### PR TITLE
Handle General number format as non date

### DIFF
--- a/src/Spout/Reader/XLSX/Helper/StyleHelper.php
+++ b/src/Spout/Reader/XLSX/Helper/StyleHelper.php
@@ -171,9 +171,21 @@ class StyleHelper
     protected function doesNumFmtIdIndicateDate($numFmtId)
     {
         return (
-            $this->isNumFmtIdBuiltInDateFormat($numFmtId) ||
-            $this->isNumFmtIdCustomDateFormat($numFmtId)
+            !$this->doesNumFmtIdIndicateGeneralFormat($numFmtId) &&
+            (
+                $this->isNumFmtIdBuiltInDateFormat($numFmtId) ||
+                $this->isNumFmtIdCustomDateFormat($numFmtId)
+            )
         );
+    }
+
+    /**
+     * @param int $numFmtId
+     * @return bool Whether the number format ID indicates the "General" format (0 by convention)
+     */
+    protected function doesNumFmtIdIndicateGeneralFormat($numFmtId)
+    {
+        return ($numFmtId === 0);
     }
 
     /**

--- a/tests/Spout/Reader/XLSX/Helper/StyleHelperTest.php
+++ b/tests/Spout/Reader/XLSX/Helper/StyleHelperTest.php
@@ -62,6 +62,16 @@ class StyleHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testShouldFormatNumericValueAsDateWithGeneralFormat()
+    {
+        $styleHelper = $this->getStyleHelperMock([[], ['applyNumberFormat' => true, 'numFmtId' => 0]]);
+        $shouldFormatAsDate = $styleHelper->shouldFormatNumericValueAsDate(1);
+        $this->assertFalse($shouldFormatAsDate);
+    }
+
+    /**
+     * @return void
+     */
     public function testShouldFormatNumericValueAsDateWithBuiltinDateFormats()
     {
         $builtinNumFmtIdsForDate = [14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47];


### PR DESCRIPTION
Fixes #212 

If the number format is set to General (id = 0), do no try to format the value as a date