### PR TITLE
Add the ability to pass an array with various keys to addRows()

### DIFF
--- a/src/Spout/Writer/AbstractWriter.php
+++ b/src/Spout/Writer/AbstractWriter.php
@@ -238,7 +238,8 @@ abstract class AbstractWriter implements WriterInterface
     public function addRows(array $dataRows)
     {
         if (!empty($dataRows)) {
-            if (!is_array($dataRows[0])) {
+            $firstRow = reset($dataRows);
+            if (!is_array($firstRow)) {
                 throw new InvalidArgumentException('The input should be an array of arrays');
             }
 


### PR DESCRIPTION
Now if you have an array of arrays with various keys (e.g. string keys), it throws InvalidArgumentException. I suppose it should not care what kind of keys has the array which will be added to a row.