### PR TITLE
Set BOM as optional on CSV writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,15 @@ Additionally, if you need to read non UTF-8 files, you can specify the encoding 
 $reader->setEncoding('UTF-16LE');
 ```
 
-The writer always generate CSV files encoded in UTF-8, with a BOM.
+By default, the writer generates CSV files encoded in UTF-8, with a BOM.
+It is however possible to not include the BOM:
+```php
+use Box\Spout\Writer\WriterFactory;
+use Box\Spout\Common\Type;
+
+$writer = WriterFactory::create(Type::CSV);
+$writer->setShouldAddBOM(false);
+```
 
 
 ### Configuring the XLSX and ODS readers and writers

--- a/src/Spout/Writer/CSV/Writer.php
+++ b/src/Spout/Writer/CSV/Writer.php
@@ -29,6 +29,9 @@ class Writer extends AbstractWriter
     /** @var int */
     protected $lastWrittenRowIndex = 0;
 
+    /** @var bool */
+    protected $shouldAddBOM = true;
+
     /**
      * Sets the field delimiter for the CSV
      *
@@ -56,14 +59,28 @@ class Writer extends AbstractWriter
     }
 
     /**
+     * Set if a BOM has to be added to the file
+     *
+     * @param bool $shouldAddBOM
+     * @return Writer
+     */
+    public function setShouldAddBOM($shouldAddBOM)
+    {
+        $this->shouldAddBOM = (bool) $shouldAddBOM;
+        return $this;
+    }
+
+    /**
      * Opens the CSV streamer and makes it ready to accept data.
      *
      * @return void
      */
     protected function openWriter()
     {
-        // Adds UTF-8 BOM for Unicode compatibility
-        $this->globalFunctionsHelper->fputs($this->filePointer, EncodingHelper::BOM_UTF8);
+        if ($this->shouldAddBOM) {
+            // Adds UTF-8 BOM for Unicode compatibility
+            $this->globalFunctionsHelper->fputs($this->filePointer, EncodingHelper::BOM_UTF8);
+        }
     }
 
     /**

--- a/tests/Spout/Writer/CSV/WriterTest.php
+++ b/tests/Spout/Writer/CSV/WriterTest.php
@@ -77,6 +77,19 @@ class WriterTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function testWriteShouldNotAddUtf8Bom()
+    {
+        $allRows = [
+            ['csv--11', 'csv--12'],
+        ];
+        $writtenContent = $this->writeToCsvFileAndReturnWrittenContent($allRows, 'csv_no_bom.csv', ',', '"', false);
+
+        $this->assertNotContains(EncodingHelper::BOM_UTF8, $writtenContent, 'The CSV file should not contain a UTF-8 BOM');
+    }
+
+    /**
+     * @return void
+     */
     public function testWriteShouldSupportAssociativeArrays()
     {
         $allRows = [
@@ -148,13 +161,14 @@ class WriterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $allRows
+     * @param array  $allRows
      * @param string $fileName
      * @param string $fieldDelimiter
      * @param string $fieldEnclosure
+     * @param bool   $shouldAddBOM
      * @return null|string
      */
-    private function writeToCsvFileAndReturnWrittenContent($allRows, $fileName, $fieldDelimiter = ',', $fieldEnclosure = '"')
+    private function writeToCsvFileAndReturnWrittenContent($allRows, $fileName, $fieldDelimiter = ',', $fieldEnclosure = '"', $shouldAddBOM = true)
     {
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
@@ -162,6 +176,7 @@ class WriterTest extends \PHPUnit_Framework_TestCase
         $writer = WriterFactory::create(Type::CSV);
         $writer->setFieldDelimiter($fieldDelimiter);
         $writer->setFieldEnclosure($fieldEnclosure);
+        $writer->setShouldAddBOM($shouldAddBOM);
 
         $writer->openToFile($resourcePath);
         $writer->addRows($allRows);


### PR DESCRIPTION
As BOM is useless with UTF-8 encoding (see https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8), add possibility to do not add it when a file is created.