### PR TITLE
Fix #276, some general refinement

### DIFF
--- a/src/Spout/Writer/XLSX/Helper/StyleHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/StyleHelper.php
@@ -92,18 +92,17 @@ class StyleHelper extends AbstractStyleHelper
         $styleId = $style->getId();
 
         if ($style->shouldApplyBorder()) {
-
             $border = $style->getBorder();
             $serializedBorder = serialize($border);
 
-            if (!isset($this->registeredBorders[$serializedBorder])) {
-
+            if (isset($this->registeredBorders[$serializedBorder])) {
+                $this->styleIdToBorderMappingTable[$styleId] = $this->registeredBorders[$serializedBorder];
+            } else {
                 $this->registeredBorders[$serializedBorder] = $styleId;
                 $this->styleIdToBorderMappingTable[$styleId] = count($this->registeredBorders);
-
             }
 
-        } else {
+        } else { // If no border should be applied - the mapping is the default border: 0
             $this->styleIdToBorderMappingTable[$styleId] = 0;
         }
     }
@@ -189,7 +188,6 @@ EOD;
 
         // The other fills are actually registered by setting a background color
         foreach ($this->registeredFills as $styleId) {
-
             /** @var Style $style */
             $style = $this->styleIdToStyleMappingTable[$styleId];
 
@@ -222,7 +220,6 @@ EOD;
         $content .= '<border><left/><right/><top/><bottom/></border>';
 
         foreach ($this->registeredBorders as $styleId) {
-
             /** @var \Box\Spout\Writer\Style\Style $style */
             $style = $this->styleIdToStyleMappingTable[$styleId];
             $border = $style->getBorder();
@@ -232,7 +229,6 @@ EOD;
             $sortOrder = ['left', 'right', 'top', 'bottom'];
 
             foreach ($sortOrder as $partName) {
-
                 if ($border->hasPart($partName)) {
                     /** @var $part \Box\Spout\Writer\Style\BorderPart */
                     $part = $border->getPart($partName);
@@ -275,7 +271,6 @@ EOD;
         $content = '<cellXfs count="' . count($registeredStyles) . '">';
 
         foreach ($registeredStyles as $style) {
-
             $styleId = $style->getId();
             $fillId = $this->styleIdToFillMappingTable[$styleId];
             $borderId = $this->styleIdToBorderMappingTable[$styleId];

--- a/src/Spout/Writer/XLSX/Helper/StyleHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/StyleHelper.php
@@ -95,14 +95,19 @@ class StyleHelper extends AbstractStyleHelper
             $border = $style->getBorder();
             $serializedBorder = serialize($border);
 
-            if (isset($this->registeredBorders[$serializedBorder])) {
-                $this->styleIdToBorderMappingTable[$styleId] = $this->registeredBorders[$serializedBorder];
+            $isBorderAlreadyRegistered = isset($this->registeredBorders[$serializedBorder]);
+
+            if ($isBorderAlreadyRegistered) {
+                $registeredStyleId = $this->registeredBorders[$serializedBorder];
+                $registeredBorderId = $this->styleIdToBorderMappingTable[$registeredStyleId];
+                $this->styleIdToBorderMappingTable[$styleId] = $registeredBorderId;
             } else {
                 $this->registeredBorders[$serializedBorder] = $styleId;
                 $this->styleIdToBorderMappingTable[$styleId] = count($this->registeredBorders);
             }
 
-        } else { // If no border should be applied - the mapping is the default border: 0
+        } else { 
+            // If no border should be applied - the mapping is the default border: 0
             $this->styleIdToBorderMappingTable[$styleId] = 0;
         }
     }

--- a/src/Spout/Writer/XLSX/Helper/StyleHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/StyleHelper.php
@@ -91,7 +91,7 @@ class StyleHelper extends AbstractStyleHelper
     {
         $styleId = $style->getId();
 
-        if (true === $style->shouldApplyBorder()) {
+        if ($style->shouldApplyBorder()) {
 
             $border = $style->getBorder();
             $serializedBorder = serialize($border);

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -420,8 +420,8 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
         // Where a border is applied - the borderId attribute has to be greater than 0
         $bordersApplied = 0;
         /** @var \DOMElement $node */
-        foreach($styleXfsElements->childNodes as $node) {
-            if($node->getAttribute('applyBorder') == 1) {
+        foreach ($styleXfsElements->childNodes as $node) {
+            if ($node->getAttribute('applyBorder') == 1) {
                 $bordersApplied++;
                 $this->assertTrue((int)$node->getAttribute('borderId') > 0, 'BorderId is greater than 0');
             } else {
@@ -429,7 +429,7 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals(2, $bordersApplied, 'Two borders have been applied');
+        $this->assertEquals(3, $bordersApplied, 'Three borders have been applied');
     }
 
     /**

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -380,11 +380,14 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
         $fontStyle = (new StyleBuilder())->setFontBold()->build();
         $emptyStyle = (new StyleBuilder())->build();
 
+        $borderRightFontBoldStyle = $borderRightStyle->mergeWith($fontStyle);
+
         $dataRows = [
             ['Border-Left'],
             ['Empty'],
             ['Font-Bold'],
-            ['Border-Right']
+            ['Border-Right'],
+            ['Border-Right-Font-Bold'],
         ];
 
         $styles = [
@@ -392,6 +395,7 @@ class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
             $emptyStyle,
             $fontStyle,
             $borderRightStyle,
+            $borderRightFontBoldStyle
         ];
         
         $this->writeToXLSXFileWithMultipleStyles($dataRows, $fileName, $styles);


### PR DESCRIPTION
This is a fix for #276. Added more tests. Addition: The ```applyBorder``` attribute is now added always to the ```cellXfs``` nodes. This is what I saw other "vendors" doing.  