### PR TITLE
Fix boolean notation in PHPDoc

### DIFF
--- a/src/Spout/Reader/CSV/RowIterator.php
+++ b/src/Spout/Reader/CSV/RowIterator.php
@@ -106,7 +106,7 @@ class RowIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Reader/CSV/SheetIterator.php
+++ b/src/Spout/Reader/CSV/SheetIterator.php
@@ -45,7 +45,7 @@ class SheetIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Reader/ODS/RowIterator.php
+++ b/src/Spout/Reader/ODS/RowIterator.php
@@ -82,7 +82,7 @@ class RowIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Reader/ODS/SheetIterator.php
+++ b/src/Spout/Reader/ODS/SheetIterator.php
@@ -83,7 +83,7 @@ class SheetIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Reader/XLSX/RowIterator.php
+++ b/src/Spout/Reader/XLSX/RowIterator.php
@@ -115,7 +115,7 @@ class RowIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Reader/XLSX/SheetIterator.php
+++ b/src/Spout/Reader/XLSX/SheetIterator.php
@@ -53,7 +53,7 @@ class SheetIterator implements IteratorInterface
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Spout/Writer/Style/Style.php
+++ b/src/Spout/Writer/Style/Style.php
@@ -115,7 +115,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function shouldApplyBorder()
     {
@@ -123,7 +123,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isFontBold()
     {
@@ -142,7 +142,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isFontItalic()
     {
@@ -161,7 +161,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isFontUnderline()
     {
@@ -180,7 +180,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isFontStrikethrough()
     {
@@ -261,7 +261,7 @@ class Style
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function shouldWrapText()
     {


### PR DESCRIPTION
As pointed out in #311 , booleans in PHPDoc should be written as 'bool', not 'boolean'.