### PR TITLE
Fix output file deletion after exception thrown on write

### DIFF
--- a/src/Spout/Common/Helper/FileSystemHelper.php
+++ b/src/Spout/Common/Helper/FileSystemHelper.php
@@ -13,15 +13,15 @@ use Box\Spout\Common\Exception\IOException;
  */
 class FileSystemHelper
 {
-    /** @var string Path of the base folder where all the I/O can occur */
-    protected $baseFolderPath;
+    /** @var string Real path of the base folder where all the I/O can occur */
+    protected $baseFolderRealPath;
 
     /**
      * @param string $baseFolderPath The path of the base folder where all the I/O can occur
      */
     public function __construct($baseFolderPath)
     {
-        $this->baseFolderPath = $baseFolderPath;
+        $this->baseFolderRealPath = realpath($baseFolderPath);
     }
 
     /**
@@ -124,9 +124,10 @@ class FileSystemHelper
      */
     protected function throwIfOperationNotInBaseFolder($operationFolderPath)
     {
-        $isInBaseFolder = (strpos($operationFolderPath, $this->baseFolderPath) === 0);
+        $operationFolderRealPath = realpath($operationFolderPath);
+        $isInBaseFolder = (strpos($operationFolderRealPath, $this->baseFolderRealPath) === 0);
         if (!$isInBaseFolder) {
-            throw new IOException("Cannot perform I/O operation outside of the base folder: {$this->baseFolderPath}");
+            throw new IOException("Cannot perform I/O operation outside of the base folder: {$this->baseFolderRealPath}");
         }
     }
 }

--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -204,18 +204,6 @@ class GlobalFunctionsHelper
     }
 
     /**
-     * Wrapper around global function dirname()
-     * @see dirname()
-     *
-     * @param string $filePath
-     * @return string
-     */
-    public function dirname($filePath)
-    {
-        return dirname($filePath);
-    }
-
-    /**
      * Wrapper around global function feof()
      * @see feof()
      *

--- a/src/Spout/Writer/AbstractWriter.php
+++ b/src/Spout/Writer/AbstractWriter.php
@@ -372,8 +372,8 @@ abstract class AbstractWriter implements WriterInterface
 
         // remove output file if it was created
         if ($this->globalFunctionsHelper->file_exists($this->outputFilePath)) {
-            $outputFolder = $this->globalFunctionsHelper->dirname($this->outputFilePath);
-            $fileSystemHelper = new FileSystemHelper($outputFolder);
+            $outputFolderPath = dirname($this->outputFilePath);
+            $fileSystemHelper = new FileSystemHelper($outputFolderPath);
             $fileSystemHelper->deleteFile($this->outputFilePath);
         }
     }

--- a/src/Spout/Writer/ODS/Helper/FileSystemHelper.php
+++ b/src/Spout/Writer/ODS/Helper/FileSystemHelper.php
@@ -75,7 +75,7 @@ class FileSystemHelper extends \Box\Spout\Common\Helper\FileSystemHelper
      */
     protected function createRootFolder()
     {
-        $this->rootFolder = $this->createFolder($this->baseFolderPath, uniqid('ods'));
+        $this->rootFolder = $this->createFolder($this->baseFolderRealPath, uniqid('ods'));
         return $this;
     }
 

--- a/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Spout/Writer/XLSX/Helper/FileSystemHelper.php
@@ -94,7 +94,7 @@ class FileSystemHelper extends \Box\Spout\Common\Helper\FileSystemHelper
      */
     protected function createRootFolder()
     {
-        $this->rootFolder = $this->createFolder($this->baseFolderPath, uniqid('xlsx', true));
+        $this->rootFolder = $this->createFolder($this->baseFolderRealPath, uniqid('xlsx', true));
         return $this;
     }
 


### PR DESCRIPTION
For relative paths, it would not work as the FileSystemHelper would not allow deleting a file that's not part of its base folder.