### PR TITLE
Remove text suffix in XLSX date formats

### DIFF
--- a/src/Spout/Reader/XLSX/Helper/DateFormatHelper.php
+++ b/src/Spout/Reader/XLSX/Helper/DateFormatHelper.php
@@ -62,7 +62,9 @@ class DateFormatHelper
     public static function toPHPDateFormat($excelDateFormat)
     {
         // Remove brackets potentially present at the beginning of the format string
-        $dateFormat = preg_replace('/^(\[\$[^\]]+?\])/i', '', $excelDateFormat);
+        // and text portion of the format at the end of it (starting with ";")
+        // See §18.8.31 of ECMA-376 for more detail.
+        $dateFormat = preg_replace('/^(?:\[\$[^\]]+?\])?([^;]*).*/', '$1', $excelDateFormat);
 
         // Double quotes are used to escape characters that must not be interpreted.
         // For instance, ["Day " dd] should result in "Day 13" and we should not try to interpret "D", "a", "y"

--- a/tests/Spout/Reader/XLSX/Helper/DateFormatHelperTest.php
+++ b/tests/Spout/Reader/XLSX/Helper/DateFormatHelperTest.php
@@ -29,6 +29,8 @@ class DateFormatHelperTest extends \PHPUnit_Framework_TestCase
             ['[$USD-F480]hh:mm AM/PM', 'h:i A'],
             ['"Day " d', '\\D\\a\\y\\  j'],
             ['yy "Year" m "Month"', 'y \\Y\\e\\a\\r n \\M\\o\\n\\t\\h'],
+            ['mmm-yy;@', 'M-y'],
+            ['[$-409]hh:mm AM/PM;"foo"@', 'h:i A'],
         ];
     }
 


### PR DESCRIPTION
Fixes #330

Some date formats have a text suffix, e.g. "mm/dd/yy;@". We should remove the ";...@" part.