### PR TITLE
Fix crash when using associative array with empty row

### DIFF
--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -149,7 +149,8 @@ EOD;
     private function isEmptyRow($dataRow)
     {
         $numCells = count($dataRow);
-        return ($numCells === 1 && CellHelper::isEmpty($dataRow[0]));
+        // using "reset()" instead of "$dataRow[0]" because $dataRow can be an associative array
+        return ($numCells === 1 && CellHelper::isEmpty(reset($dataRow)));
     }
 
     /**

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -294,7 +294,7 @@ class WriterTest extends \PHPUnit_Framework_TestCase
         $dataRows = [
             [''],
             ['xlsx--21', 'xlsx--22'],
-            [''],
+            ['key' => ''],
             [''],
             ['xlsx--51', 'xlsx--52'],
         ];


### PR DESCRIPTION
Fixes #353