### PR TITLE
Fixed processDimensionStartingNode regular expression

### DIFF
--- a/src/Spout/Reader/XLSX/RowIterator.php
+++ b/src/Spout/Reader/XLSX/RowIterator.php
@@ -220,9 +220,8 @@ class RowIterator implements IteratorInterface
     {
         // Read dimensions of the sheet
         $dimensionRef = $xmlReader->getAttribute(self::XML_ATTRIBUTE_REF); // returns 'A1:M13' for instance (or 'A1' for empty sheet)
-        if (preg_match('/[A-Z\d]+:([A-Z\d]+)/', $dimensionRef, $matches)) {
-            $lastCellIndex = $matches[1];
-            $this->numColumns = CellHelper::getColumnIndexFromCellIndex($lastCellIndex) + 1;
+        if (preg_match('/[A-Z]+\d+:([A-Z]+\d+)/', $dimensionRef, $matches)) {
+            $this->numColumns = CellHelper::getColumnIndexFromCellIndex($matches[1]) + 1;
         }
 
         return XMLProcessor::PROCESSING_CONTINUE;

--- a/src/Spout/Reader/XLSX/RowIterator.php
+++ b/src/Spout/Reader/XLSX/RowIterator.php
@@ -220,7 +220,7 @@ class RowIterator implements IteratorInterface
     {
         // Read dimensions of the sheet
         $dimensionRef = $xmlReader->getAttribute(self::XML_ATTRIBUTE_REF); // returns 'A1:M13' for instance (or 'A1' for empty sheet)
-        if (preg_match('/^[A-Z]+\d+:([A-Z]+\d+)$/', $dimensionRef, $matches)) {
+        if (preg_match('/[A-Z]+\d+:([A-Z]+\d+)/', $dimensionRef, $matches)) {
             $this->numColumns = CellHelper::getColumnIndexFromCellIndex($matches[1]) + 1;
         }
 

--- a/src/Spout/Reader/XLSX/RowIterator.php
+++ b/src/Spout/Reader/XLSX/RowIterator.php
@@ -220,7 +220,7 @@ class RowIterator implements IteratorInterface
     {
         // Read dimensions of the sheet
         $dimensionRef = $xmlReader->getAttribute(self::XML_ATTRIBUTE_REF); // returns 'A1:M13' for instance (or 'A1' for empty sheet)
-        if (preg_match('/[A-Z]+\d+:([A-Z]+\d+)/', $dimensionRef, $matches)) {
+        if (preg_match('/^[A-Z]+\d+:([A-Z]+\d+)$/', $dimensionRef, $matches)) {
             $this->numColumns = CellHelper::getColumnIndexFromCellIndex($matches[1]) + 1;
         }
 


### PR DESCRIPTION
I'm working with release `2.6` but the bug is the same.

Current regular expression `/[A-Z\d]+:([A-Z\d]+)/` is not checking format `A1:M13`, is checking anything with `A-Z OR number : A-Z OR number`.

On some of my sheets (one in a document with 12 sheets), at this point returns `1:141` as a valid value.

This fix force to check `A-Z AND number : A-Z AND number`.

Regards.