### PR TITLE
ensure libxml entity loading is enabled

### DIFF
--- a/src/Spout/Reader/Wrapper/XMLReader.php
+++ b/src/Spout/Reader/Wrapper/XMLReader.php
@@ -16,6 +16,12 @@ class XMLReader extends \XMLReader
 
     const ZIP_WRAPPER = 'zip://';
 
+    public function __construct()
+    {
+        // ensure libxml entity loading is enabled
+        libxml_disable_entity_loader(false);
+    }
+
     /**
      * Opens the XML Reader to read a file located inside a ZIP file.
      *


### PR DESCRIPTION
I had an issue where another part of my app was setting `libxml_disable_entity_loader(true)`. This caused failures when using spout. Would this change be acceptable?