### PR TITLE
Adding support for 'getActiveSheet' method

### DIFF
--- a/src/Spout/Reader/XLSX/Helper/SheetHelper.php
+++ b/src/Spout/Reader/XLSX/Helper/SheetHelper.php
@@ -85,7 +85,7 @@ class SheetHelper
         if ($xmlReader->openFileInZip($this->filePath, self::WORKBOOK_XML_FILE_PATH)) {
             while ($xmlReader->read()) {
                 if ($xmlReader->isPositionedOnStartingNode('workbookView')) {
-                    $activeSheetIndex = $xmlReader->getAttribute('activeTab');
+                    $activeSheetIndex = (int) $xmlReader->getAttribute('activeTab');
                 }
             }
             $xmlReader->close();

--- a/src/Spout/Reader/XLSX/Helper/SheetHelper.php
+++ b/src/Spout/Reader/XLSX/Helper/SheetHelper.php
@@ -73,6 +73,28 @@ class SheetHelper
     }
 
     /**
+     * Get active sheet index
+     *
+     * @return int index of active sheet
+     */
+    public function getActiveSheetIndex()
+    {
+        $activeSheetIndex = 0;
+
+        $xmlReader = new XMLReader();
+        if ($xmlReader->openFileInZip($this->filePath, self::WORKBOOK_XML_FILE_PATH)) {
+            while ($xmlReader->read()) {
+                if ($xmlReader->isPositionedOnStartingNode('workbookView')) {
+                    $activeSheetIndex = $xmlReader->getAttribute('activeTab');
+                }
+            }
+            $xmlReader->close();
+        }
+
+        return $activeSheetIndex;
+    }
+
+    /**
      * Returns an instance of a sheet, given the XML node describing the sheet - from "workbook.xml".
      * We can find the XML file path describing the sheet inside "workbook.xml.res", by mapping with the sheet ID
      * ("r:id" in "workbook.xml", "Id" in "workbook.xml.res").

--- a/src/Spout/Reader/XLSX/SheetIterator.php
+++ b/src/Spout/Reader/XLSX/SheetIterator.php
@@ -20,6 +20,9 @@ class SheetIterator implements IteratorInterface
     /** @var int The index of the sheet being read (zero-based) */
     protected $currentSheetIndex;
 
+    /** @var  int The index of the sheet which is active */
+    protected $activeSheetIndex;
+
     /**
      * @param string $filePath Path of the file to be read
      * @param \Box\Spout\Reader\XLSX\ReaderOptions $options Reader's current options
@@ -32,10 +35,21 @@ class SheetIterator implements IteratorInterface
         // Fetch all available sheets
         $sheetHelper = new SheetHelper($filePath, $options, $sharedStringsHelper, $globalFunctionsHelper);
         $this->sheets = $sheetHelper->getSheets();
+        $this->activeSheetIndex = $sheetHelper->getActiveSheetIndex();
 
         if (count($this->sheets) === 0) {
             throw new NoSheetsFoundException('The file must contain at least one sheet.');
         }
+    }
+
+    /**
+     * Retrieve active sheet
+     *
+     * @return Sheet
+     */
+    public function getActiveSheet()
+    {
+        return $this->sheets[$this->activeSheetIndex];
     }
 
     /**


### PR DESCRIPTION
This is actually an enhancement - https://github.com/box/spout/issues/386

Libraries like PHPExcel has 'getActiveSheet' method which can get you the active sheet(the sheet which is opened) from your workbook. 

After this change, you can use following code to get the active sheet

`$sheet = $reader->getSheetIterator()->getActiveSheet();`