### PR TITLE
Make XLSX shared strings path case insensitive

### DIFF
--- a/src/Spout/Reader/XLSX/Reader.php
+++ b/src/Spout/Reader/XLSX/Reader.php
@@ -74,9 +74,9 @@ class Reader extends AbstractReader
         if ($this->zip->open($filePath) === true) {
             $this->sharedStringsHelper = new SharedStringsHelper($filePath, $this->getOptions()->getTempFolder());
 
-            if ($this->sharedStringsHelper->hasSharedStrings()) {
+            if ($sharedStringsPath = $this->sharedStringsHelper->getSharedStringsPath()) {
                 // Extracts all the strings from the sheets for easy access in the future
-                $this->sharedStringsHelper->extractSharedStrings();
+                $this->sharedStringsHelper->extractSharedStrings($sharedStringsPath);
             }
 
             $this->sheetIterator = new SheetIterator($filePath, $this->getOptions(), $this->sharedStringsHelper, $this->globalFunctionsHelper);


### PR DESCRIPTION
Some XLSX files have shared strings XML name started with uppercase letter (SharedStrings.xml). So XMLReader can't find required file in that situation.