### PR TITLE
Write formulas to XLSX files.

### DIFF
--- a/src/Spout/Writer/Common/Helper/CellHelper.php
+++ b/src/Spout/Writer/Common/Helper/CellHelper.php
@@ -65,6 +65,17 @@ class CellHelper
     }
 
     /**
+     * Returns whether the given value looks like a formula
+     *
+     * @param $value
+     * @return bool whether the given value looks like a formula
+     */
+    public static function isFormulaString($value)
+    {
+        return (strpos($value,'=') === 0);
+    }
+
+    /**
      * Returns whether the given value is numeric.
      * A numeric value is from type "integer" or "double" ("float" is not returned by gettype).
      *

--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -212,8 +212,10 @@ EOD;
         $columnIndex = CellHelper::getCellIndexFromColumnIndex($cellNumber);
         $cellXML = '<c r="' . $columnIndex . $rowIndex . '"';
         $cellXML .= ' s="' . $styleId . '"';
-
-        if (CellHelper::isNonEmptyString($cellValue)) {
+        
+        if (CellHelper::isFormulaString($cellValue)) {
+            $cellXML .= '><f>'.substr($cellValue,1).'</f><v>0</v></c>'; // seriously, that's it.
+        } else if (CellHelper::isNonEmptyString($cellValue)) {
             $cellXML .= $this->getCellXMLFragmentForNonEmptyString($cellValue);
         } else if (CellHelper::isBoolean($cellValue)) {
             $cellXML .= ' t="b"><v>' . intval($cellValue) . '</v></c>';


### PR DESCRIPTION
Ref this issue: https://github.com/box/spout/issues/424

I utterly understand that reading formulas is a pain.  It should be noted that writing formulas to ODS is rather a pain, too, but the nature of xlsx actually makes it rather easy to write them.

This way, we can use the super-performant spout when we want to generate an xlsx file that needs to contain some excel formulas, and I don't think this lands outside of the goals of Spout.

I await your judgement!