### PR TITLE
HHVM is no longer supported on Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.4
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - hhvm-3.6
 
 cache:
   directories:
@@ -19,5 +21,5 @@ script:
   - php vendor/bin/phpunit --coverage-clover=build/logs/coverage.clover
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/coverage.clover; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm-3.6' && $TRAVIS_PHP_VERSION != '7.0' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm-3.6' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/coverage.clover; fi


### PR DESCRIPTION
Travis says:

> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.