### PR TITLE
Allow setting of header content type for CSVs.

### DIFF
--- a/src/Spout/Writer/AbstractWriter.php
+++ b/src/Spout/Writer/AbstractWriter.php
@@ -37,7 +37,7 @@ abstract class AbstractWriter implements WriterInterface
     protected $defaultRowStyle;
 
     /** @var string Content-Type value for the header - to be defined by child class */
-    protected static $headerContentType;
+    protected $headerContentType;
 
     /**
      * Opens the streamer and makes it ready to accept data.
@@ -143,7 +143,7 @@ abstract class AbstractWriter implements WriterInterface
         $this->globalFunctionsHelper->ob_end_clean();
 
         // Set headers
-        $this->globalFunctionsHelper->header('Content-Type: ' . static::$headerContentType);
+        $this->globalFunctionsHelper->header('Content-Type: ' . $this->headerContentType);
         $this->globalFunctionsHelper->header('Content-Disposition: attachment; filename="' . $this->outputFilePath . '"');
 
         /*

--- a/src/Spout/Writer/CSV/Writer.php
+++ b/src/Spout/Writer/CSV/Writer.php
@@ -18,7 +18,7 @@ class Writer extends AbstractWriter
     const FLUSH_THRESHOLD = 500;
 
     /** @var string Content-Type value for the header */
-    protected static $headerContentType = 'text/csv; charset=UTF-8';
+    protected $headerContentType = 'text/csv; charset=UTF-8';
 
     /** @var string Defines the character used to delimit fields (one character only) */
     protected $fieldDelimiter = ',';
@@ -55,6 +55,18 @@ class Writer extends AbstractWriter
     public function setFieldEnclosure($fieldEnclosure)
     {
         $this->fieldEnclosure = $fieldEnclosure;
+        return $this;
+    }
+
+    /**
+     * Set the header content type.
+     *
+     * @param string $headerContentType Content-Type value for the header if different than default UTF-8.
+     * @return Writer
+     */
+    public function setHeaderContentType($headerContentType)
+    {
+        $this->headerContentType = $headerContentType;
         return $this;
     }
 

--- a/src/Spout/Writer/ODS/Writer.php
+++ b/src/Spout/Writer/ODS/Writer.php
@@ -15,7 +15,7 @@ use Box\Spout\Writer\ODS\Internal\Workbook;
 class Writer extends AbstractMultiSheetsWriter
 {
     /** @var string Content-Type value for the header */
-    protected static $headerContentType = 'application/vnd.oasis.opendocument.spreadsheet';
+    protected $headerContentType = 'application/vnd.oasis.opendocument.spreadsheet';
 
     /** @var string Temporary folder where the files to create the ODS will be stored */
     protected $tempFolder;

--- a/src/Spout/Writer/XLSX/Writer.php
+++ b/src/Spout/Writer/XLSX/Writer.php
@@ -19,7 +19,7 @@ class Writer extends AbstractMultiSheetsWriter
     const DEFAULT_FONT_NAME = 'Calibri';
 
     /** @var string Content-Type value for the header */
-    protected static $headerContentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    protected $headerContentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
     /** @var string Temporary folder where the files to create the XLSX will be stored */
     protected $tempFolder;


### PR DESCRIPTION
Setting a different header content type can be useful (for CSVs) if different encoding is used for example.