### PR TITLE
Favor object creation in factories

### DIFF
--- a/src/Spout/Reader/CSV/Creator/EntityFactory.php
+++ b/src/Spout/Reader/CSV/Creator/EntityFactory.php
@@ -37,18 +37,19 @@ class EntityFactory implements EntityFactoryInterface
      */
     public function createSheetIterator($filePointer, $optionsManager, $globalFunctionsHelper)
     {
-        return new SheetIterator($filePointer, $optionsManager, $globalFunctionsHelper, $this);
+        $rowIterator = $this->createRowIterator($filePointer, $optionsManager, $globalFunctionsHelper);
+        $sheet = $this->createSheet($rowIterator);
+
+        return new SheetIterator($sheet);
     }
 
     /**
-     * @param resource $filePointer Pointer to the CSV file to read
-     * @param OptionsManagerInterface $optionsManager
-     * @param GlobalFunctionsHelper $globalFunctionsHelper
+     * @param RowIterator $rowIterator
      * @return Sheet
      */
-    public function createSheet($filePointer, $optionsManager, $globalFunctionsHelper)
+    private function createSheet($rowIterator)
     {
-        return new Sheet($filePointer, $optionsManager, $globalFunctionsHelper, $this);
+        return new Sheet($rowIterator);
     }
 
     /**
@@ -57,7 +58,7 @@ class EntityFactory implements EntityFactoryInterface
      * @param GlobalFunctionsHelper $globalFunctionsHelper
      * @return RowIterator
      */
-    public function createRowIterator($filePointer, $optionsManager, $globalFunctionsHelper)
+    private function createRowIterator($filePointer, $optionsManager, $globalFunctionsHelper)
     {
         $encodingHelper = $this->helperFactory->createEncodingHelper($globalFunctionsHelper);
         return new RowIterator($filePointer, $optionsManager, $encodingHelper, $globalFunctionsHelper);

--- a/src/Spout/Reader/CSV/Sheet.php
+++ b/src/Spout/Reader/CSV/Sheet.php
@@ -16,14 +16,11 @@ class Sheet implements SheetInterface
     protected $rowIterator;
 
     /**
-     * @param resource $filePointer Pointer to the CSV file to read
-     * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager
-     * @param \Box\Spout\Common\Helper\GlobalFunctionsHelper $globalFunctionsHelper
-     * @param EntityFactory $entityFactory Factory to create entities
+     * @param RowIterator $rowIterator Corresponding row iterator
      */
-    public function __construct($filePointer, $optionsManager, $globalFunctionsHelper, $entityFactory)
+    public function __construct(RowIterator $rowIterator)
     {
-        $this->rowIterator = $entityFactory->createRowIterator($filePointer, $optionsManager, $globalFunctionsHelper);
+        $this->rowIterator = $rowIterator;
     }
 
     /**

--- a/src/Spout/Reader/CSV/SheetIterator.php
+++ b/src/Spout/Reader/CSV/SheetIterator.php
@@ -20,14 +20,11 @@ class SheetIterator implements IteratorInterface
     protected $hasReadUniqueSheet = false;
 
     /**
-     * @param resource $filePointer
-     * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager
-     * @param \Box\Spout\Common\Helper\GlobalFunctionsHelper $globalFunctionsHelper
-     * @param EntityFactory $entityFactory Factory to create entities
+     * @param Sheet $sheet Corresponding unique sheet
      */
-    public function __construct($filePointer, $optionsManager, $globalFunctionsHelper, $entityFactory)
+    public function __construct($sheet)
     {
-        $this->sheet = $entityFactory->createSheet($filePointer, $optionsManager, $globalFunctionsHelper);
+        $this->sheet = $sheet;
     }
 
     /**

--- a/src/Spout/Reader/ODS/RowIterator.php
+++ b/src/Spout/Reader/ODS/RowIterator.php
@@ -9,6 +9,7 @@ use Box\Spout\Reader\Exception\XMLProcessingException;
 use Box\Spout\Reader\IteratorInterface;
 use Box\Spout\Reader\ODS\Creator\EntityFactory;
 use Box\Spout\Reader\ODS\Creator\HelperFactory;
+use Box\Spout\Reader\ODS\Helper\CellValueFormatter;
 use Box\Spout\Reader\Wrapper\XMLReader;
 use Box\Spout\Reader\Common\XMLProcessor;
 
@@ -75,17 +76,17 @@ class RowIterator implements IteratorInterface
     /**
      * @param XMLReader $xmlReader XML Reader, positioned on the "<table:table>" element
      * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
-     * @param EntityFactory $entityFactory Factory to create entities
-     * @param HelperFactory $helperFactory Factory to create helpers
+     * @param CellValueFormatter $cellValueFormatter Helper to format cell values
+     * @param XMLProcessor $xmlProcessor Helper to process XML files
      */
-    public function __construct($xmlReader, $optionsManager, $entityFactory, $helperFactory)
+    public function __construct($xmlReader, $optionsManager, $cellValueFormatter, $xmlProcessor)
     {
         $this->xmlReader = $xmlReader;
         $this->shouldPreserveEmptyRows = $optionsManager->getOption(Options::SHOULD_PRESERVE_EMPTY_ROWS);
-        $this->cellValueFormatter = $helperFactory->createCellValueFormatter($optionsManager->getOption(Options::SHOULD_FORMAT_DATES));
+        $this->cellValueFormatter = $cellValueFormatter;
 
         // Register all callbacks to process different nodes when reading the XML file
-        $this->xmlProcessor = $entityFactory->createXMLProcessor($this->xmlReader);
+        $this->xmlProcessor = $xmlProcessor;
         $this->xmlProcessor->registerCallback(self::XML_NODE_ROW, XMLProcessor::NODE_TYPE_START, [$this, 'processRowStartingNode']);
         $this->xmlProcessor->registerCallback(self::XML_NODE_CELL, XMLProcessor::NODE_TYPE_START, [$this, 'processCellStartingNode']);
         $this->xmlProcessor->registerCallback(self::XML_NODE_ROW, XMLProcessor::NODE_TYPE_END, [$this, 'processRowEndingNode']);

--- a/src/Spout/Reader/ODS/Sheet.php
+++ b/src/Spout/Reader/ODS/Sheet.php
@@ -30,16 +30,14 @@ class Sheet implements SheetInterface
     protected $isActive;
 
     /**
-     * @param XMLReader $xmlReader XML Reader, positioned on the "<table:table>" element
+     * @param RowIterator $rowIterator The corresponding row iterator
      * @param int $sheetIndex Index of the sheet, based on order in the workbook (zero-based)
      * @param string $sheetName Name of the sheet
      * @param bool $isSheetActive Whether the sheet was defined as active
-     * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
-     * @param EntityFactory $entityFactory Factory to create entities
      */
-    public function __construct($xmlReader, $sheetIndex, $sheetName, $isSheetActive, $optionsManager, $entityFactory)
+    public function __construct($rowIterator, $sheetIndex, $sheetName, $isSheetActive)
     {
-        $this->rowIterator = $entityFactory->createRowIterator($xmlReader, $optionsManager);
+        $this->rowIterator = $rowIterator;
         $this->index = $sheetIndex;
         $this->name = $sheetName;
         $this->isActive = $isSheetActive;

--- a/src/Spout/Reader/ODS/SheetIterator.php
+++ b/src/Spout/Reader/ODS/SheetIterator.php
@@ -51,19 +51,17 @@ class SheetIterator implements IteratorInterface
     /**
      * @param string $filePath Path of the file to be read
      * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager
+     * @param \Box\Spout\Common\Helper\Escaper\ODS $escaper Used to unescape XML data
+     * @param SettingsHelper $settingsHelper Helper to get data from "settings.xml"
      * @param EntityFactory $entityFactory Factory to create entities
-     * @param HelperFactory $helperFactory Factory to create helpers
      */
-    public function __construct($filePath, $optionsManager, $entityFactory, $helperFactory)
+    public function __construct($filePath, $optionsManager, $escaper, $settingsHelper, $entityFactory)
     {
         $this->filePath = $filePath;
         $this->optionsManager = $optionsManager;
         $this->entityFactory = $entityFactory;
         $this->xmlReader = $entityFactory->createXMLReader();
-
-        $this->escaper = $helperFactory->createStringsEscaper();
-
-        $settingsHelper = $helperFactory->createSettingsHelper($entityFactory);
+        $this->escaper = $escaper;
         $this->activeSheetName = $settingsHelper->getActiveSheetName($filePath);
     }
 

--- a/src/Spout/Reader/XLSX/Creator/HelperFactory.php
+++ b/src/Spout/Reader/XLSX/Creator/HelperFactory.php
@@ -44,14 +44,13 @@ class HelperFactory extends \Box\Spout\Common\Creator\HelperFactory
      * @param string $filePath Path of the XLSX file being read
      * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
      * @param \Box\Spout\Reader\XLSX\Helper\SharedStringsHelper Helper to work with shared strings
-     * @param \Box\Spout\Common\Helper\GlobalFunctionsHelper $globalFunctionsHelper
      * @param EntityFactory $entityFactory Factory to create entities
      * @return SheetHelper
      */
-    public function createSheetHelper($filePath, $optionsManager, $sharedStringsHelper, $globalFunctionsHelper, $entityFactory)
+    public function createSheetHelper($filePath, $optionsManager, $sharedStringsHelper, $entityFactory)
     {
         $escaper = $this->createStringsEscaper();
-        return new SheetHelper($filePath, $optionsManager, $sharedStringsHelper, $globalFunctionsHelper, $escaper, $entityFactory);
+        return new SheetHelper($filePath, $optionsManager, $sharedStringsHelper, $escaper, $entityFactory);
     }
 
     /**

--- a/src/Spout/Reader/XLSX/Helper/SheetHelper.php
+++ b/src/Spout/Reader/XLSX/Helper/SheetHelper.php
@@ -53,16 +53,14 @@ class SheetHelper
      * @param string $filePath Path of the XLSX file being read
      * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
      * @param \Box\Spout\Reader\XLSX\Helper\SharedStringsHelper Helper to work with shared strings
-     * @param \Box\Spout\Common\Helper\GlobalFunctionsHelper $globalFunctionsHelper
      * @param \Box\Spout\Common\Helper\Escaper\XLSX $escaper Used to unescape XML data
      * @param EntityFactory $entityFactory Factory to create entities
      */
-    public function __construct($filePath, $optionsManager, $sharedStringsHelper, $globalFunctionsHelper, $escaper, $entityFactory)
+    public function __construct($filePath, $optionsManager, $sharedStringsHelper, $escaper, $entityFactory)
     {
         $this->filePath = $filePath;
         $this->optionsManager = $optionsManager;
         $this->sharedStringsHelper = $sharedStringsHelper;
-        $this->globalFunctionsHelper = $globalFunctionsHelper;
         $this->escaper = $escaper;
         $this->entityFactory = $entityFactory;
     }

--- a/src/Spout/Reader/XLSX/Sheet.php
+++ b/src/Spout/Reader/XLSX/Sheet.php
@@ -26,25 +26,14 @@ class Sheet implements SheetInterface
     protected $isActive;
 
     /**
-     * @param string $filePath Path of the XLSX file being read
-     * @param string $sheetDataXMLFilePath Path of the sheet data XML file as in [Content_Types].xml
+     * @param RowIterator $rowIterator The corresponding row iterator
      * @param int $sheetIndex Index of the sheet, based on order in the workbook (zero-based)
      * @param string $sheetName Name of the sheet
      * @param bool $isSheetActive Whether the sheet was defined as active
-     * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
-     * @param Helper\SharedStringsHelper $sharedStringsHelper Helper to work with shared strings
-     * @param EntityFactory $entityFactory Factory to create entities
      */
-    public function __construct(
-        $filePath,
-        $sheetDataXMLFilePath,
-        $sheetIndex, $sheetName,
-        $isSheetActive,
-        $optionsManager,
-        $sharedStringsHelper,
-        $entityFactory)
+    public function __construct($rowIterator, $sheetIndex, $sheetName, $isSheetActive)
     {
-        $this->rowIterator = $entityFactory->createRowIterator($filePath, $sheetDataXMLFilePath, $optionsManager, $sharedStringsHelper);
+        $this->rowIterator = $rowIterator;
         $this->index = $sheetIndex;
         $this->name = $sheetName;
         $this->isActive = $isSheetActive;

--- a/src/Spout/Reader/XLSX/SheetIterator.php
+++ b/src/Spout/Reader/XLSX/SheetIterator.php
@@ -23,24 +23,12 @@ class SheetIterator implements IteratorInterface
     protected $currentSheetIndex;
 
     /**
-     * @param string $filePath Path of the file to be read
-     * @param \Box\Spout\Common\Manager\OptionsManagerInterface $optionsManager Reader's options manager
-     * @param \Box\Spout\Reader\XLSX\Helper\SharedStringsHelper $sharedStringsHelper
-     * @param \Box\Spout\Common\Helper\GlobalFunctionsHelper $globalFunctionsHelper
-     * @param EntityFactory $entityFactory Factory to create entities
-     * @param HelperFactory $helperFactory Factory to create helpers
+     * @param SheetHelper $sheetHelper Helper to work with sheets
      * @throws \Box\Spout\Reader\Exception\NoSheetsFoundException If there are no sheets in the file
      */
-    public function __construct(
-        $filePath,
-        $optionsManager,
-        $sharedStringsHelper,
-        $globalFunctionsHelper,
-        $entityFactory,
-        $helperFactory)
+    public function __construct($sheetHelper)
     {
         // Fetch all available sheets
-        $sheetHelper = $helperFactory->createSheetHelper($filePath, $optionsManager, $sharedStringsHelper, $globalFunctionsHelper, $entityFactory);
         $this->sheets = $sheetHelper->getSheets();
 
         if (count($this->sheets) === 0) {


### PR DESCRIPTION
Instead of passing factories in the constructors and let objects call the factory method, create all dependencies directly in the factories.