### PR TITLE
Change Worksheet function visibility from private to protected

### DIFF
--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -159,7 +159,7 @@ EOD;
      *          Example $dataRow = ['data1', 1234, null, '', 'data5'];
      * @return bool Whether the given row is empty
      */
-    private function isEmptyRow($dataRow)
+    protected function isEmptyRow($dataRow)
     {
         $numCells = count($dataRow);
         // using "reset()" instead of "$dataRow[0]" because $dataRow can be an associative array
@@ -176,7 +176,7 @@ EOD;
      * @throws \Box\Spout\Common\Exception\IOException If the data cannot be written
      * @throws \Box\Spout\Common\Exception\InvalidArgumentException If a cell value's type is not supported
      */
-    private function addNonEmptyRow($dataRow, $style)
+    protected function addNonEmptyRow($dataRow, $style)
     {
         $cellNumber = 0;
         $rowIndex = $this->lastWrittenRowIndex + 1;
@@ -207,7 +207,7 @@ EOD;
      * @return string
      * @throws InvalidArgumentException If the given value cannot be processed
      */
-    private function getCellXML($rowIndex, $cellNumber, $cellValue, $styleId)
+    protected function getCellXML($rowIndex, $cellNumber, $cellValue, $styleId)
     {
         $columnIndex = CellHelper::getCellIndexFromColumnIndex($cellNumber);
         $cellXML = '<c r="' . $columnIndex . $rowIndex . '"';
@@ -241,7 +241,7 @@ EOD;
      * @return string The XML fragment representing the cell
      * @throws InvalidArgumentException If the string exceeds the maximum number of characters allowed per cell
      */
-    private function getCellXMLFragmentForNonEmptyString($cellValue)
+    protected function getCellXMLFragmentForNonEmptyString($cellValue)
     {
         if ($this->stringHelper->getStringLength($cellValue) > self::MAX_CHARACTERS_PER_CELL) {
             throw new InvalidArgumentException('Trying to add a value that exceeds the maximum number of characters allowed in a cell (32,767)');


### PR DESCRIPTION
We have created small package on top of the Spout for support cell number format and per cell styles, so we need to call parent functions.