### PR TITLE
As per RFC-4180 regarding CSV, "If double-quotes are used to enclose …

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -86,7 +86,7 @@ class GlobalFunctionsHelper
      */
     public function fgetcsv($handle, $length = null, $delimiter = null, $enclosure = null)
     {
-        return fgetcsv($handle, $length, $delimiter, $enclosure);
+        return fgetcsv($handle, $length, $delimiter, $enclosure, $enclosure);
     }
 
     /**
@@ -101,7 +101,7 @@ class GlobalFunctionsHelper
      */
     public function fputcsv($handle, array $fields, $delimiter = null, $enclosure = null)
     {
-        return fputcsv($handle, $fields, $delimiter, $enclosure);
+        return fputcsv($handle, $fields, $delimiter, $enclosure, $enclosure);
     }
 
     /**


### PR DESCRIPTION
…fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote".

So we are changing the calls to fgetcsv and fputcsv on GlobalFunctionsHelper in order to send the Escape Character as a parameter. To be RFC compliant, we always send the same character as the Field Enclosure character.