### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-xmlreader" : "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.0",
+        "phpunit/phpunit": "^5.7.0 || ^6.4.0",
         "friendsofphp/php-cs-fixer": "^2.7.0"
     },
     "suggest": {

--- a/tests/Spout/Common/Entity/Style/BorderTest.php
+++ b/tests/Spout/Common/Entity/Style/BorderTest.php
@@ -6,11 +6,12 @@ use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
 use Box\Spout\Writer\Exception\Border\InvalidNameException;
 use Box\Spout\Writer\Exception\Border\InvalidStyleException;
 use Box\Spout\Writer\Exception\Border\InvalidWidthException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BorderTest
  */
-class BorderTest extends \PHPUnit_Framework_TestCase
+class BorderTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Spout/Common/Entity/Style/ColorTest.php
+++ b/tests/Spout/Common/Entity/Style/ColorTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Common\Entity\Style;
 
 use Box\Spout\Common\Exception\InvalidColorException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ColorTest
  */
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Common/Helper/CellTypeHelperTest.php
+++ b/tests/Spout/Common/Helper/CellTypeHelperTest.php
@@ -2,10 +2,12 @@
 
 namespace Box\Spout\Common\Helper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CellTypeHelperTest
  */
-class CellTypeHelperTest extends \PHPUnit_Framework_TestCase
+class CellTypeHelperTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Common/Helper/EncodingHelperTest.php
+++ b/tests/Spout/Common/Helper/EncodingHelperTest.php
@@ -4,11 +4,12 @@ namespace Box\Spout\Common\Helper;
 
 use Box\Spout\Common\Exception\EncodingConversionException;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class EncodingHelperTest
  */
-class EncodingHelperTest extends \PHPUnit_Framework_TestCase
+class EncodingHelperTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Common/Helper/Escaper/ODSTest.php
+++ b/tests/Spout/Common/Helper/Escaper/ODSTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Common\Helper\Escaper;
 
 use Box\Spout\Common\Helper\Escaper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ODSTest
  */
-class ODSTest extends \PHPUnit_Framework_TestCase
+class ODSTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Common/Helper/Escaper/XLSXTest.php
+++ b/tests/Spout/Common/Helper/Escaper/XLSXTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Common\Helper\Escaper;
 
 use Box\Spout\Common\Helper\Escaper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class XLSXTest
  */
-class XLSXTest extends \PHPUnit_Framework_TestCase
+class XLSXTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Common/Helper/FileSystemHelperTest.php
+++ b/tests/Spout/Common/Helper/FileSystemHelperTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Common\Helper;
 
 use Box\Spout\Common\Exception\IOException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FileSystemHelperTest
  */
-class FileSystemHelperTest extends \PHPUnit_Framework_TestCase
+class FileSystemHelperTest extends TestCase
 {
     /** @var \Box\Spout\Writer\XLSX\Helper\FileSystemHelper */
     protected $fileSystemHelper;

--- a/tests/Spout/Common/Manager/OptionsManagerTest.php
+++ b/tests/Spout/Common/Manager/OptionsManagerTest.php
@@ -2,10 +2,12 @@
 
 namespace Box\Spout\Common\Manager;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class OptionsManagerTest
  */
-class OptionsManagerTest extends \PHPUnit_Framework_TestCase
+class OptionsManagerTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Spout/Reader/CSV/ReaderTest.php
+++ b/tests/Spout/Reader/CSV/ReaderTest.php
@@ -11,11 +11,12 @@ use Box\Spout\Reader\CSV\Manager\OptionsManager;
 use Box\Spout\Reader\Exception\ReaderNotOpenedException;
 use Box\Spout\Reader\ReaderInterface;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ReaderTest
  */
-class ReaderTest extends \PHPUnit_Framework_TestCase
+class ReaderTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/CSV/SheetTest.php
+++ b/tests/Spout/Reader/CSV/SheetTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Reader\CSV;
 use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\EntityFactory;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/Common/Manager/RowManagerTest.php
+++ b/tests/Spout/Reader/Common/Manager/RowManagerTest.php
@@ -7,11 +7,12 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Reader\XLSX\Creator\HelperFactory;
 use Box\Spout\Reader\XLSX\Creator\InternalEntityFactory;
 use Box\Spout\Reader\XLSX\Creator\ManagerFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RowManagerTest
  */
-class RowManagerTest extends \PHPUnit_Framework_TestCase
+class RowManagerTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Reader/ODS/ReaderTest.php
+++ b/tests/Spout/Reader/ODS/ReaderTest.php
@@ -7,11 +7,12 @@ use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\EntityFactory;
 use Box\Spout\Reader\Exception\IteratorNotRewindableException;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ReaderTest
  */
-class ReaderTest extends \PHPUnit_Framework_TestCase
+class ReaderTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/ODS/SheetTest.php
+++ b/tests/Spout/Reader/ODS/SheetTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Reader\ODS;
 use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\EntityFactory;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/ReaderFactoryTest.php
+++ b/tests/Spout/Reader/ReaderFactoryTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Reader;
 
 use Box\Spout\Common\Exception\UnsupportedTypeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ReaderFactoryTest
  */
-class ReaderFactoryTest extends \PHPUnit_Framework_TestCase
+class ReaderFactoryTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Spout/Reader/Wrapper/XMLReaderTest.php
+++ b/tests/Spout/Reader/Wrapper/XMLReaderTest.php
@@ -4,11 +4,12 @@ namespace Box\Spout\Reader\Wrapper;
 
 use Box\Spout\Reader\Exception\XMLProcessingException;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class XMLReaderTest
  */
-class XMLReaderTest extends \PHPUnit_Framework_TestCase
+class XMLReaderTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/XLSX/Helper/CellHelperTest.php
+++ b/tests/Spout/Reader/XLSX/Helper/CellHelperTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Reader\XLSX\Helper;
 
 use Box\Spout\Common\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CellHelperTest
  */
-class CellHelperTest extends \PHPUnit_Framework_TestCase
+class CellHelperTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Reader/XLSX/Helper/CellValueFormatterTest.php
+++ b/tests/Spout/Reader/XLSX/Helper/CellValueFormatterTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Reader\XLSX\Helper;
 use Box\Spout\Common\Helper\Escaper;
 use Box\Spout\Reader\Exception\InvalidValueException;
 use Box\Spout\Reader\XLSX\Manager\StyleManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CellValueFormatterTest
  */
-class CellValueFormatterTest extends \PHPUnit_Framework_TestCase
+class CellValueFormatterTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Reader/XLSX/Helper/DateFormatHelperTest.php
+++ b/tests/Spout/Reader/XLSX/Helper/DateFormatHelperTest.php
@@ -2,10 +2,12 @@
 
 namespace Box\Spout\Reader\XLSX\Helper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class DateFormatHelperTest
  */
-class DateFormatHelperTest extends \PHPUnit_Framework_TestCase
+class DateFormatHelperTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Reader/XLSX/Manager/SharedStringsCaching/CachingStrategyFactoryTest.php
+++ b/tests/Spout/Reader/XLSX/Manager/SharedStringsCaching/CachingStrategyFactoryTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Reader\XLSX\Manager\SharedStringsCaching;
 
 use Box\Spout\Reader\XLSX\Creator\HelperFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CachingStrategyFactoryTest
  */
-class CachingStrategyFactoryTest extends \PHPUnit_Framework_TestCase
+class CachingStrategyFactoryTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Reader/XLSX/Manager/SharedStringsManagerTest.php
+++ b/tests/Spout/Reader/XLSX/Manager/SharedStringsManagerTest.php
@@ -10,11 +10,12 @@ use Box\Spout\Reader\XLSX\Manager\SharedStringsCaching\CachingStrategyFactory;
 use Box\Spout\Reader\XLSX\Manager\SharedStringsCaching\FileBasedStrategy;
 use Box\Spout\Reader\XLSX\Manager\SharedStringsCaching\InMemoryStrategy;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SharedStringsManagerTest
  */
-class SharedStringsManagerTest extends \PHPUnit_Framework_TestCase
+class SharedStringsManagerTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Spout/Reader/XLSX/Manager/StyleManagerTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Reader\XLSX\Manager;
 
 use Box\Spout\Reader\XLSX\Creator\InternalEntityFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleManagerTest
  */
-class StyleManagerTest extends \PHPUnit_Framework_TestCase
+class StyleManagerTest extends TestCase
 {
     /**
      * @param array $styleAttributes

--- a/tests/Spout/Reader/XLSX/ReaderTest.php
+++ b/tests/Spout/Reader/XLSX/ReaderTest.php
@@ -6,11 +6,12 @@ use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\EntityFactory;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ReaderTest
  */
-class ReaderTest extends \PHPUnit_Framework_TestCase
+class ReaderTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Reader/XLSX/SheetTest.php
+++ b/tests/Spout/Reader/XLSX/SheetTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Reader\XLSX;
 use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\EntityFactory;
 use Box\Spout\TestUsingResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     use TestUsingResource;
 

--- a/tests/Spout/Writer/CSV/WriterTest.php
+++ b/tests/Spout/Writer/CSV/WriterTest.php
@@ -11,11 +11,12 @@ use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\EntityFactory;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
 use Box\Spout\Writer\RowCreationHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterTest
  */
-class WriterTest extends \PHPUnit_Framework_TestCase
+class WriterTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;

--- a/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
+++ b/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Writer\Common\Creator\Style;
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Writer\Common\Manager\Style\StyleMerger;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleManagerTest
  */
-class StyleBuilderTest extends \PHPUnit_Framework_TestCase
+class StyleBuilderTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Spout/Writer/Common/Creator/WriterFactoryTest.php
+++ b/tests/Spout/Writer/Common/Creator/WriterFactoryTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Writer\Common\Creator;
 
 use Box\Spout\Common\Exception\UnsupportedTypeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterFactoryTest
  */
-class WriterFactoryTest extends \PHPUnit_Framework_TestCase
+class WriterFactoryTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Spout/Writer/Common/Entity/SheetTest.php
+++ b/tests/Spout/Writer/Common/Entity/SheetTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Writer\Common\Entity;
 use Box\Spout\Common\Helper\StringHelper;
 use Box\Spout\Writer\Common\Manager\SheetManager;
 use Box\Spout\Writer\Exception\InvalidSheetNameException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     /** @var SheetManager */
     private $sheetManager;

--- a/tests/Spout/Writer/Common/Helper/CellHelperTest.php
+++ b/tests/Spout/Writer/Common/Helper/CellHelperTest.php
@@ -2,10 +2,12 @@
 
 namespace Box\Spout\Writer\Common\Helper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CellHelperTest
  */
-class CellHelperTest extends \PHPUnit_Framework_TestCase
+class CellHelperTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Writer/Common/Manager/Style/StyleManagerTest.php
+++ b/tests/Spout/Writer/Common/Manager/Style/StyleManagerTest.php
@@ -4,11 +4,12 @@ namespace Box\Spout\Writer\Common\Manager\Style;
 
 use Box\Spout\Common\Entity\Cell;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleManagerTest
  */
-class StyleManagerTest extends \PHPUnit_Framework_TestCase
+class StyleManagerTest extends TestCase
 {
     /**
      * @return StyleManager

--- a/tests/Spout/Writer/Common/Manager/Style/StyleMergerTest.php
+++ b/tests/Spout/Writer/Common/Manager/Style/StyleMergerTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Writer\Common\Manager\Style;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Common\Entity\Style\Style;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleMergerTest
  */
-class StyleMergerTest extends \PHPUnit_Framework_TestCase
+class StyleMergerTest extends TestCase
 {
     /** @var StyleMerger */
     private $styleMerger;

--- a/tests/Spout/Writer/Common/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/Common/Manager/Style/StyleRegistryTest.php
@@ -4,11 +4,12 @@ namespace Box\Spout\Writer\Common\Manager\Style;
 
 use Box\Spout\Common\Entity\Style\Style;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleRegistryTest
  */
-class StyleRegistryTest extends \PHPUnit_Framework_TestCase
+class StyleRegistryTest extends TestCase
 {
     /** @var Style */
     private $defaultStyle;

--- a/tests/Spout/Writer/ODS/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/ODS/Manager/Style/StyleRegistryTest.php
@@ -3,11 +3,12 @@
 namespace Box\Spout\Writer\ODS\Manager\Style;
 
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleRegistryTest
  */
-class StyleRegistryTest extends \PHPUnit_Framework_TestCase
+class StyleRegistryTest extends TestCase
 {
     /**
      * @return StyleRegistry

--- a/tests/Spout/Writer/ODS/SheetTest.php
+++ b/tests/Spout/Writer/ODS/SheetTest.php
@@ -8,11 +8,12 @@ use Box\Spout\Writer\Common\Creator\EntityFactory;
 use Box\Spout\Writer\Common\Entity\Sheet;
 use Box\Spout\Writer\Exception\InvalidSheetNameException;
 use Box\Spout\Writer\RowCreationHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;

--- a/tests/Spout/Writer/ODS/WriterTest.php
+++ b/tests/Spout/Writer/ODS/WriterTest.php
@@ -14,11 +14,12 @@ use Box\Spout\Writer\Common\Helper\ZipHelper;
 use Box\Spout\Writer\Exception\WriterAlreadyOpenedException;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
 use Box\Spout\Writer\RowCreationHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterTest
  */
-class WriterTest extends \PHPUnit_Framework_TestCase
+class WriterTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;
@@ -135,7 +136,7 @@ class WriterTest extends \PHPUnit_Framework_TestCase
             $writer->addRows($dataRows);
             $this->fail('Exception should have been thrown');
         } catch (SpoutException $e) {
-            $this->assertFalse(file_exists($fileName), 'Output file should have been deleted');
+            $this->assertFileNotExists($fileName, 'Output file should have been deleted');
 
             $numFiles = iterator_count(new \FilesystemIterator($tempFolderPath, \FilesystemIterator::SKIP_DOTS));
             $this->assertEquals(0, $numFiles, 'All temp files should have been deleted');

--- a/tests/Spout/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/ODS/WriterWithStyleTest.php
@@ -14,11 +14,12 @@ use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
 use Box\Spout\Writer\RowCreationHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterWithStyleTest
  */
-class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
+class WriterWithStyleTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;

--- a/tests/Spout/Writer/XLSX/Manager/Style/StyleManagerTest.php
+++ b/tests/Spout/Writer/XLSX/Manager/Style/StyleManagerTest.php
@@ -2,10 +2,12 @@
 
 namespace Box\Spout\Writer\XLSX\Manager\Style;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class StyleManagerTest
  */
-class StyleManagerTest extends \PHPUnit_Framework_TestCase
+class StyleManagerTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
@@ -5,11 +5,12 @@ namespace Box\Spout\Writer\XLSX\Manager\Style;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StyleRegistryTest
  */
-class StyleRegistryTest extends \PHPUnit_Framework_TestCase
+class StyleRegistryTest extends TestCase
 {
     /**
      * @return StyleRegistry

--- a/tests/Spout/Writer/XLSX/SheetTest.php
+++ b/tests/Spout/Writer/XLSX/SheetTest.php
@@ -8,11 +8,12 @@ use Box\Spout\Writer\Common\Creator\EntityFactory;
 use Box\Spout\Writer\Common\Entity\Sheet;
 use Box\Spout\Writer\Exception\InvalidSheetNameException;
 use Box\Spout\Writer\RowCreationHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SheetTest
  */
-class SheetTest extends \PHPUnit_Framework_TestCase
+class SheetTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -13,11 +13,12 @@ use Box\Spout\Writer\Exception\WriterAlreadyOpenedException;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
 use Box\Spout\Writer\RowCreationHelper;
 use Box\Spout\Writer\XLSX\Manager\WorksheetManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterTest
  */
-class WriterTest extends \PHPUnit_Framework_TestCase
+class WriterTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;
@@ -166,7 +167,7 @@ class WriterTest extends \PHPUnit_Framework_TestCase
             $writer->addRows($dataRows);
             $this->fail('Exception should have been thrown');
         } catch (SpoutException $e) {
-            $this->assertFalse(file_exists($fileName), 'Output file should have been deleted');
+            $this->assertFileNotExists($fileName, 'Output file should have been deleted');
 
             $numFiles = iterator_count(new \FilesystemIterator($tempFolderPath, \FilesystemIterator::SKIP_DOTS));
             $this->assertEquals(0, $numFiles, 'All temp files should have been deleted');

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -17,11 +17,12 @@ use Box\Spout\Writer\Common\Manager\Style\StyleMerger;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
 use Box\Spout\Writer\RowCreationHelper;
 use Box\Spout\Writer\XLSX\Manager\OptionsManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WriterWithStyleTest
  */
-class WriterWithStyleTest extends \PHPUnit_Framework_TestCase
+class WriterWithStyleTest extends TestCase
 {
     use TestUsingResource;
     use RowCreationHelper;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.