### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Spout/Common/Entity/RowTest.php
+++ b/tests/Spout/Common/Entity/RowTest.php
@@ -96,6 +96,6 @@ class RowTest extends \PHPUnit\Framework\TestCase
             ->setStyle($this->getStyleMock())
             ->setCells([]);
 
-        $this->assertTrue(is_object($row));
+        $this->assertInternalType('object', $row);
     }
 }

--- a/tests/Spout/Common/Entity/Style/BorderTest.php
+++ b/tests/Spout/Common/Entity/Style/BorderTest.php
@@ -67,7 +67,7 @@ class BorderTest extends TestCase
             ->addPart(new BorderPart(Border::BOTTOM))
             ->addPart(new BorderPart(Border::LEFT));
 
-        $this->assertEquals(4, count($border->getParts()), 'There should never be more than 4 border parts');
+        $this->assertCount(4, $border->getParts(), 'There should never be more than 4 border parts');
     }
 
     /**
@@ -80,7 +80,7 @@ class BorderTest extends TestCase
             new BorderPart(Border::LEFT),
         ]);
 
-        $this->assertEquals(1, count($border->getParts()), 'It should be possible to set the border parts');
+        $this->assertCount(1, $border->getParts(), 'It should be possible to set the border parts');
     }
 
     /**
@@ -94,7 +94,7 @@ class BorderTest extends TestCase
             ->setBorderLeft()
             ->setBorderRight()
             ->build();
-        $this->assertEquals(4, count($border->getParts()), 'The border builder exposes a fluent interface');
+        $this->assertCount(4, $border->getParts(), 'The border builder exposes a fluent interface');
     }
 
     /**
@@ -110,7 +110,7 @@ class BorderTest extends TestCase
                     $borderPart = new BorderPart($allowedName, $color, $allowedWidth, $allowedStyle);
                     $border = new Border();
                     $border->addPart($borderPart);
-                    $this->assertEquals(1, count($border->getParts()));
+                    $this->assertCount(1, $border->getParts());
 
                     /** @var $part BorderPart */
                     $part = $border->getParts()[$allowedName];

--- a/tests/Spout/Common/Manager/OptionsManagerTest.php
+++ b/tests/Spout/Common/Manager/OptionsManagerTest.php
@@ -16,7 +16,7 @@ class OptionsManagerTest extends TestCase
     {
         $optionsManager = new FakeOptionsManager();
         $this->assertEquals('foo-val', $optionsManager->getOption('foo'));
-        $this->assertEquals(false, $optionsManager->getOption('bar'));
+        $this->assertFalse($optionsManager->getOption('bar'));
     }
 
     /**

--- a/tests/Spout/Reader/ODS/ReaderTest.php
+++ b/tests/Spout/Reader/ODS/ReaderTest.php
@@ -64,9 +64,9 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile($resourceName);
 
-        $this->assertEquals($expectedNumOfRows, count($allRows), "There should be $expectedNumOfRows rows");
+        $this->assertCount($expectedNumOfRows, $allRows, "There should be $expectedNumOfRows rows");
         foreach ($allRows as $row) {
-            $this->assertEquals($expectedNumOfCellsPerRow, count($row), "There should be $expectedNumOfCellsPerRow cells for every row");
+            $this->assertCount($expectedNumOfCellsPerRow, $row, "There should be $expectedNumOfCellsPerRow cells for every row");
         }
     }
 
@@ -228,7 +228,7 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_with_empty_rows.ods');
 
-        $this->assertEquals(3, count($allRows), 'There should be only 3 rows, because the empty rows are skipped');
+        $this->assertCount(3, $allRows, 'There should be only 3 rows, because the empty rows are skipped');
 
         $expectedRows = [
             // skipped row here
@@ -248,7 +248,7 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_with_empty_rows.ods', false, true);
 
-        $this->assertEquals(6, count($allRows), 'There should be 6 rows');
+        $this->assertCount(6, $allRows, 'There should be 6 rows');
 
         $expectedRows = [
             [''],

--- a/tests/Spout/Reader/Wrapper/XMLReaderTest.php
+++ b/tests/Spout/Reader/Wrapper/XMLReaderTest.php
@@ -25,7 +25,7 @@ class XMLReaderTest extends TestCase
         // using "@" to prevent errors/warning to be displayed
         $wasOpenSuccessful = @$xmlReader->openFileInZip($resourcePath, 'path/to/fake/file.xml');
 
-        $this->assertTrue($wasOpenSuccessful === false);
+        $this->assertFalse($wasOpenSuccessful);
     }
 
     /**
@@ -47,8 +47,8 @@ class XMLReaderTest extends TestCase
 
             // using the built-in XMLReader
             $xmlReader = new \XMLReader();
-            $this->assertTrue($xmlReader->open($nonExistingXMLFilePath) !== false);
-            $this->assertTrue(libxml_get_last_error() === false);
+            $this->assertNotFalse($xmlReader->open($nonExistingXMLFilePath));
+            $this->assertFalse(libxml_get_last_error());
 
             libxml_use_internal_errors($initialUseInternalErrorsSetting);
         }

--- a/tests/Spout/Reader/XLSX/ReaderTest.php
+++ b/tests/Spout/Reader/XLSX/ReaderTest.php
@@ -67,9 +67,9 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile($resourceName);
 
-        $this->assertEquals($expectedNumOfRows, count($allRows), "There should be $expectedNumOfRows rows");
+        $this->assertCount($expectedNumOfRows, $allRows, "There should be $expectedNumOfRows rows");
         foreach ($allRows as $row) {
-            $this->assertEquals($expectedNumOfCellsPerRow, count($row), "There should be $expectedNumOfCellsPerRow cells for every row");
+            $this->assertCount($expectedNumOfCellsPerRow, $row, "There should be $expectedNumOfCellsPerRow cells for every row");
         }
     }
 
@@ -373,9 +373,9 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_without_dimensions_but_spans_and_empty_cells.xlsx');
 
-        $this->assertEquals(2, count($allRows), 'There should be 2 rows');
+        $this->assertCount(2, $allRows, 'There should be 2 rows');
         foreach ($allRows as $row) {
-            $this->assertEquals(5, count($row), 'There should be 5 cells for every row, because empty rows should be preserved');
+            $this->assertCount(5, $row, 'There should be 5 cells for every row, because empty rows should be preserved');
         }
 
         $expectedRows = [
@@ -392,9 +392,9 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_without_dimensions_and_empty_cells.xlsx');
 
-        $this->assertEquals(2, count($allRows), 'There should be 2 rows');
-        $this->assertEquals(5, count($allRows[0]), 'There should be 5 cells in the first row');
-        $this->assertEquals(3, count($allRows[1]), 'There should be only 3 cells in the second row, because empty rows at the end should be skip');
+        $this->assertCount(2, $allRows, 'There should be 2 rows');
+        $this->assertCount(5, $allRows[0], 'There should be 5 cells in the first row');
+        $this->assertCount(3, $allRows[1], 'There should be only 3 cells in the second row, because empty rows at the end should be skip');
 
         $expectedRows = [
             ['s1--A1', 's1--B1', 's1--C1', 's1--D1', 's1--E1'],
@@ -410,9 +410,9 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_without_dimensions_and_empty_cells.xlsx');
 
-        $this->assertEquals(2, count($allRows), 'There should be 2 rows');
-        $this->assertEquals(5, count($allRows[0]), 'There should be 5 cells in the first row');
-        $this->assertEquals(3, count($allRows[1]), 'There should be only 3 cells in the second row, because empty rows at the end should be skip');
+        $this->assertCount(2, $allRows, 'There should be 2 rows');
+        $this->assertCount(5, $allRows[0], 'There should be 5 cells in the first row');
+        $this->assertCount(3, $allRows[1], 'There should be only 3 cells in the second row, because empty rows at the end should be skip');
 
         $expectedRows = [
             ['s1--A1', 's1--B1', 's1--C1', 's1--D1', 's1--E1'],
@@ -428,7 +428,7 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_with_empty_rows_and_missing_row_index.xlsx');
 
-        $this->assertEquals(3, count($allRows), 'There should be only 3 rows, because the empty rows are skipped');
+        $this->assertCount(3, $allRows, 'There should be only 3 rows, because the empty rows are skipped');
 
         $expectedRows = [
             // skipped row here
@@ -448,7 +448,7 @@ class ReaderTest extends TestCase
     {
         $allRows = $this->getAllRowsForFile('sheet_with_empty_rows_and_missing_row_index.xlsx', false, true);
 
-        $this->assertEquals(6, count($allRows), 'There should be 6 rows');
+        $this->assertCount(6, $allRows, 'There should be 6 rows');
 
         $expectedRows = [
             [],

--- a/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
+++ b/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
@@ -37,7 +37,7 @@ class StyleBuilderTest extends TestCase
         $styleMerger = new StyleMerger();
         $mergedStyle = $styleMerger->merge($currentStyle, $baseStyle);
 
-        $this->assertEquals(null, $currentStyle->getBorder(), 'Current style has no border');
+        $this->assertNull($currentStyle->getBorder(), 'Current style has no border');
         $this->assertInstanceOf(Border::class, $baseStyle->getBorder(), 'Base style has a border');
         $this->assertInstanceOf(Border::class, $mergedStyle->getBorder(), 'Merged style has a border');
     }

--- a/tests/Spout/Writer/Common/Manager/Style/StyleMergerTest.php
+++ b/tests/Spout/Writer/Common/Manager/Style/StyleMergerTest.php
@@ -153,6 +153,6 @@ class StyleMergerTest extends TestCase
         $fakeStyle = (new StyleBuilder())->build();
         $styleRegistry = new StyleRegistry($fakeStyle);
 
-        $this->assertTrue($styleRegistry->serialize($style1) === $styleRegistry->serialize($style2));
+        $this->assertSame($styleRegistry->serialize($style1), $styleRegistry->serialize($style2));
     }
 }

--- a/tests/Spout/Writer/ODS/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/ODS/Manager/Style/StyleRegistryTest.php
@@ -27,7 +27,7 @@ class StyleRegistryTest extends TestCase
     {
         $styleRegistry = $this->getStyleRegistry();
 
-        $this->assertEquals(1, count($styleRegistry->getUsedFonts()), 'There should only be the default font name');
+        $this->assertCount(1, $styleRegistry->getUsedFonts(), 'There should only be the default font name');
 
         $style1 = (new StyleBuilder())->setFontName('MyFont1')->build();
         $styleRegistry->registerStyle($style1);
@@ -35,6 +35,6 @@ class StyleRegistryTest extends TestCase
         $style2 = (new StyleBuilder())->setFontName('MyFont2')->build();
         $styleRegistry->registerStyle($style2);
 
-        $this->assertEquals(3, count($styleRegistry->getUsedFonts()), 'There should be 3 fonts registered');
+        $this->assertCount(3, $styleRegistry->getUsedFonts(), 'There should be 3 fonts registered');
     }
 }

--- a/tests/Spout/Writer/ODS/SheetTest.php
+++ b/tests/Spout/Writer/ODS/SheetTest.php
@@ -25,7 +25,7 @@ class SheetTest extends TestCase
     {
         $sheets = $this->writeDataToMulitpleSheetsAndReturnSheets('test_get_sheet_index.ods');
 
-        $this->assertEquals(2, count($sheets), '2 sheets should have been created');
+        $this->assertCount(2, $sheets, '2 sheets should have been created');
         $this->assertEquals(0, $sheets[0]->getIndex(), 'The first sheet should be index 0');
         $this->assertEquals(1, $sheets[1]->getIndex(), 'The second sheet should be index 1');
     }
@@ -37,7 +37,7 @@ class SheetTest extends TestCase
     {
         $sheets = $this->writeDataToMulitpleSheetsAndReturnSheets('test_get_sheet_name.ods');
 
-        $this->assertEquals(2, count($sheets), '2 sheets should have been created');
+        $this->assertCount(2, $sheets, '2 sheets should have been created');
         $this->assertEquals('Sheet1', $sheets[0]->getName(), 'Invalid name for the first sheet');
         $this->assertEquals('Sheet2', $sheets[1]->getName(), 'Invalid name for the second sheet');
     }

--- a/tests/Spout/Writer/ODS/WriterTest.php
+++ b/tests/Spout/Writer/ODS/WriterTest.php
@@ -159,7 +159,7 @@ class WriterTest extends TestCase
         $writer->close();
 
         $sheets = $writer->getSheets();
-        $this->assertEquals(2, count($sheets), 'There should be 2 sheets');
+        $this->assertCount(2, $sheets, 'There should be 2 sheets');
         $this->assertEquals($sheets[1], $writer->getCurrentSheet(), 'The current sheet should be the second one.');
     }
 
@@ -398,7 +398,7 @@ class WriterTest extends TestCase
         \ReflectionHelper::setStaticValue('\Box\Spout\Writer\ODS\Manager\WorkbookManager', 'maxRowsPerWorksheet', 2);
 
         $writer = $this->writeToODSFile($dataRows, $fileName, $shouldCreateSheetsAutomatically = true);
-        $this->assertEquals(2, count($writer->getSheets()), '2 sheets should have been created.');
+        $this->assertCount(2, $writer->getSheets(), '2 sheets should have been created.');
 
         $this->assertValueWasNotWrittenToSheet($fileName, 1, 'ods--sheet2--11');
         $this->assertValueWasWrittenToSheet($fileName, 2, 'ods--sheet2--11');
@@ -422,7 +422,7 @@ class WriterTest extends TestCase
         \ReflectionHelper::setStaticValue('\Box\Spout\Writer\ODS\Manager\WorkbookManager', 'maxRowsPerWorksheet', 2);
 
         $writer = $this->writeToODSFile($dataRows, $fileName, $shouldCreateSheetsAutomatically = false);
-        $this->assertEquals(1, count($writer->getSheets()), 'Only 1 sheet should have been created.');
+        $this->assertCount(1, $writer->getSheets(), 'Only 1 sheet should have been created.');
 
         $this->assertValueWasNotWrittenToSheet($fileName, 1, 'ods--sheet1--31');
 

--- a/tests/Spout/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/ODS/WriterWithStyleTest.php
@@ -85,7 +85,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $cellStyleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
-        $this->assertEquals(3, count($cellStyleElements), 'There should be 3 separate cell styles, including the default one.');
+        $this->assertCount(3, $cellStyleElements, 'There should be 3 separate cell styles, including the default one.');
 
         // Second font should contain data from the first created style
         $customFont1Element = $cellStyleElements[1];
@@ -136,7 +136,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $cellDomElements = $this->getCellElementsFromContentXmlFile($fileName);
-        $this->assertEquals(3, count($cellDomElements), 'There should be 3 cells with content');
+        $this->assertCount(3, $cellDomElements, 'There should be 3 cells with content');
 
         $this->assertEquals('ce2', $cellDomElements[0]->getAttribute('table:style-name'));
         $this->assertEquals('ce3', $cellDomElements[1]->getAttribute('table:style-name'));
@@ -159,7 +159,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $cellDomElements = $this->getCellElementsFromContentXmlFile($fileName);
-        $this->assertEquals(2, count($cellDomElements), 'There should be 2 cells with content');
+        $this->assertCount(2, $cellDomElements, 'There should be 2 cells with content');
 
         $this->assertEquals('ce2', $cellDomElements[0]->getAttribute('table:style-name'));
         $this->assertEquals('ce2', $cellDomElements[1]->getAttribute('table:style-name'));
@@ -180,7 +180,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
-        $this->assertEquals(2, count($styleElements), 'There should be 2 styles (default and custom)');
+        $this->assertCount(2, $styleElements, 'There should be 2 styles (default and custom)');
 
         $customStyleElement = $styleElements[1];
         $this->assertFirstChildHasAttributeEquals('wrap', $customStyleElement, 'table-cell-properties', 'fo:wrap-option');
@@ -199,7 +199,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
-        $this->assertEquals(2, count($styleElements), 'There should be 2 styles (default and custom)');
+        $this->assertCount(2, $styleElements, 'There should be 2 styles (default and custom)');
 
         $customStyleElement = $styleElements[1];
         $this->assertFirstChildHasAttributeEquals('wrap', $customStyleElement, 'table-cell-properties', 'fo:wrap-option');
@@ -246,7 +246,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToODSFile($dataRows, $fileName);
 
         $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
-        $this->assertEquals(2, count($styleElements), 'There should be 2 styles (default and custom)');
+        $this->assertCount(2, $styleElements, 'There should be 2 styles (default and custom)');
 
         $customStyleElement = $styleElements[1];
         $this->assertFirstChildHasAttributeEquals('#' . Color::WHITE, $customStyleElement, 'table-cell-properties', 'fo:background-color');
@@ -281,7 +281,7 @@ class WriterWithStyleTest extends TestCase
 
         $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
 
-        $this->assertEquals(3, count($styleElements), 'There should be 3 styles)');
+        $this->assertCount(3, $styleElements, 'There should be 3 styles)');
 
         // Use reflection for protected members here
         $widthMap = \ReflectionHelper::getStaticValue('Box\Spout\Writer\ODS\Helper\BorderHelper', 'widthMap');

--- a/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
@@ -39,7 +39,7 @@ class StyleRegistryTest extends TestCase
         $styleRegistry->registerStyle($styleOrangeBold);
         $styleRegistry->registerStyle($styleNoBackgroundColor);
 
-        $this->assertEquals(2, count($styleRegistry->getRegisteredFills()), 'There should be 2 registered fills');
+        $this->assertCount(2, $styleRegistry->getRegisteredFills(), 'There should be 2 registered fills');
 
         $this->assertEquals(2, $styleRegistry->getFillIdForStyleId($styleBlack->getId()), 'First style with background color set should have index 2 (0 and 1 being reserved)');
         $this->assertEquals(3, $styleRegistry->getFillIdForStyleId($styleOrange->getId()), 'Second style with background color set - different from first style - should have index 3');
@@ -67,7 +67,7 @@ class StyleRegistryTest extends TestCase
         $styleRegistry->registerStyle($styleBoderRightBold);
         $styleRegistry->registerStyle($styleNoBorder);
 
-        $this->assertEquals(2, count($styleRegistry->getRegisteredBorders()), 'There should be 2 registered borders');
+        $this->assertCount(2, $styleRegistry->getRegisteredBorders(), 'There should be 2 registered borders');
 
         $this->assertEquals(1, $styleRegistry->getBorderIdForStyleId($styleBorderLeft->getId()), 'First style with border set should have index 1 (0 is for the default style)');
         $this->assertEquals(2, $styleRegistry->getBorderIdForStyleId($styleBoderRight->getId()), 'Second style with border set - different from first style - should have index 2');

--- a/tests/Spout/Writer/XLSX/SheetTest.php
+++ b/tests/Spout/Writer/XLSX/SheetTest.php
@@ -25,7 +25,7 @@ class SheetTest extends TestCase
     {
         $sheets = $this->writeDataToMultipleSheetsAndReturnSheets('test_get_sheet_index.xlsx');
 
-        $this->assertEquals(2, count($sheets), '2 sheets should have been created');
+        $this->assertCount(2, $sheets, '2 sheets should have been created');
         $this->assertEquals(0, $sheets[0]->getIndex(), 'The first sheet should be index 0');
         $this->assertEquals(1, $sheets[1]->getIndex(), 'The second sheet should be index 1');
     }
@@ -37,7 +37,7 @@ class SheetTest extends TestCase
     {
         $sheets = $this->writeDataToMultipleSheetsAndReturnSheets('test_get_sheet_name.xlsx');
 
-        $this->assertEquals(2, count($sheets), '2 sheets should have been created');
+        $this->assertCount(2, $sheets, '2 sheets should have been created');
         $this->assertEquals('Sheet1', $sheets[0]->getName(), 'Invalid name for the first sheet');
         $this->assertEquals('Sheet2', $sheets[1]->getName(), 'Invalid name for the second sheet');
     }

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -190,7 +190,7 @@ class WriterTest extends TestCase
         $writer->close();
 
         $sheets = $writer->getSheets();
-        $this->assertEquals(2, count($sheets), 'There should be 2 sheets');
+        $this->assertCount(2, $sheets, 'There should be 2 sheets');
         $this->assertEquals($sheets[1], $writer->getCurrentSheet(), 'The current sheet should be the second one.');
     }
 
@@ -454,7 +454,7 @@ class WriterTest extends TestCase
         \ReflectionHelper::setStaticValue('\Box\Spout\Writer\XLSX\Manager\WorkbookManager', 'maxRowsPerWorksheet', 2);
 
         $writer = $this->writeToXLSXFile($dataRows, $fileName, true, $shouldCreateSheetsAutomatically = true);
-        $this->assertEquals(2, count($writer->getSheets()), '2 sheets should have been created.');
+        $this->assertCount(2, $writer->getSheets(), '2 sheets should have been created.');
 
         $this->assertInlineDataWasNotWrittenToSheet($fileName, 1, 'xlsx--sheet2--11');
         $this->assertInlineDataWasWrittenToSheet($fileName, 2, 'xlsx--sheet2--11');
@@ -478,7 +478,7 @@ class WriterTest extends TestCase
         \ReflectionHelper::setStaticValue('\Box\Spout\Writer\XLSX\Manager\WorkbookManager', 'maxRowsPerWorksheet', 2);
 
         $writer = $this->writeToXLSXFile($dataRows, $fileName, true, $shouldCreateSheetsAutomatically = false);
-        $this->assertEquals(1, count($writer->getSheets()), 'Only 1 sheet should have been created.');
+        $this->assertCount(1, $writer->getSheets(), 'Only 1 sheet should have been created.');
 
         $this->assertInlineDataWasNotWrittenToSheet($fileName, 1, 'xlsx--sheet1--31');
 

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -137,7 +137,7 @@ class WriterWithStyleTest extends TestCase
         $this->writeToXLSXFile($dataRows, $fileName);
 
         $cellDomElements = $this->getCellElementsFromSheetXmlFile($fileName);
-        $this->assertEquals(3, count($cellDomElements), 'There should be 3 cells.');
+        $this->assertCount(3, $cellDomElements, 'There should be 3 cells.');
 
         $this->assertEquals('1', $cellDomElements[0]->getAttribute('s'));
         $this->assertEquals('2', $cellDomElements[1]->getAttribute('s'));
@@ -171,7 +171,7 @@ class WriterWithStyleTest extends TestCase
         // The first and second rows should not have a reference to the empty cell
         // The other rows should have the reference because style should be applied to them
         // So that's: 2 + 2 + 3 + 3 = 10 cells
-        $this->assertEquals(10, count($cellDomElements));
+        $this->assertCount(10, $cellDomElements);
 
         // First row has 2 styled cells
         $this->assertEquals('0', $cellDomElements[0]->getAttribute('s'));
@@ -499,9 +499,9 @@ class WriterWithStyleTest extends TestCase
             $shouldApplyBorder = ((int) $node->getAttribute('applyBorder') === 1);
             if ($shouldApplyBorder) {
                 $bordersApplied++;
-                $this->assertTrue((int) $node->getAttribute('borderId') > 0, 'BorderId is greater than 0');
+                $this->assertGreaterThan(0, (int) $node->getAttribute('borderId'), 'BorderId is greater than 0');
             } else {
-                $this->assertTrue((int) $node->getAttribute('borderId') === 0, 'BorderId is 0');
+                $this->assertSame(0, (int) $node->getAttribute('borderId'), 'BorderId is 0');
             }
         }
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` instead of `is_object` function;
- `assertFalse` and `assertNotFalse` instead of comparison with `false` keyword;
- `assertNull` instead of comparison with `false` keyword;
- `assertSame` and `assertNotSame` instead of strict comparison `===`;
- `assertGreaterThan` for mathematical comparison.