### PR TITLE
added setColumnsWidth method

### DIFF
--- a/src/Spout/Writer/XLSX/Internal/Workbook.php
+++ b/src/Spout/Writer/XLSX/Internal/Workbook.php
@@ -35,14 +35,18 @@ class Workbook extends AbstractWorkbook
     /** @var \Box\Spout\Writer\XLSX\Helper\StyleHelper Helper to apply styles */
     protected $styleHelper;
 
+    /** @var array Collection of column width */
+    protected $columnsWidth;
+
     /**
      * @param string $tempFolder
      * @param bool $shouldUseInlineStrings
      * @param bool $shouldCreateNewSheetsAutomatically
+     * @param array $columnsWidth
      * @param \Box\Spout\Writer\Style\Style $defaultRowStyle
      * @throws \Box\Spout\Common\Exception\IOException If unable to create at least one of the base folders
      */
-    public function __construct($tempFolder, $shouldUseInlineStrings, $shouldCreateNewSheetsAutomatically, $defaultRowStyle)
+    public function __construct($tempFolder, $shouldUseInlineStrings, $shouldCreateNewSheetsAutomatically, $defaultRowStyle, $columnsWidth)
     {
         parent::__construct($shouldCreateNewSheetsAutomatically, $defaultRowStyle);
 
@@ -52,6 +56,7 @@ class Workbook extends AbstractWorkbook
         $this->fileSystemHelper->createBaseFilesAndFolders();
 
         $this->styleHelper = new StyleHelper($defaultRowStyle);
+        $this->columnsWidth = $columnsWidth;
 
         // This helper will be shared by all sheets
         $xlFolder = $this->fileSystemHelper->getXlFolder();
@@ -75,6 +80,17 @@ class Workbook extends AbstractWorkbook
     }
 
     /**
+     * Defines column width for one or more columns of the worksheet.
+     *
+     * @param array $columnsWidth
+     * @return void
+     */
+    public function setColumnsWidth($columnsWidth)
+    {
+        $this->columnsWidth = $columnsWidth;
+    }
+
+    /**
      * Creates a new sheet in the workbook. The current sheet remains unchanged.
      *
      * @return Worksheet The created sheet
@@ -86,7 +102,7 @@ class Workbook extends AbstractWorkbook
         $sheet = new Sheet($newSheetIndex, $this->internalId);
 
         $worksheetFilesFolder = $this->fileSystemHelper->getXlWorksheetsFolder();
-        $worksheet = new Worksheet($sheet, $worksheetFilesFolder, $this->sharedStringsHelper, $this->styleHelper, $this->shouldUseInlineStrings);
+        $worksheet = new Worksheet($sheet, $worksheetFilesFolder, $this->sharedStringsHelper, $this->styleHelper, $this->shouldUseInlineStrings, $this->columnsWidth);
         $this->worksheets[] = $worksheet;
 
         return $worksheet;

--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -57,15 +57,19 @@ EOD;
     /** @var int Index of the last written row */
     protected $lastWrittenRowIndex = 0;
 
+    /** @var array Collection of column width */
+    protected $columnsWidth;
+
     /**
      * @param \Box\Spout\Writer\Common\Sheet $externalSheet The associated "external" sheet
      * @param string $worksheetFilesFolder Temporary folder where the files to create the XLSX will be stored
      * @param \Box\Spout\Writer\XLSX\Helper\SharedStringsHelper $sharedStringsHelper Helper for shared strings
      * @param \Box\Spout\Writer\XLSX\Helper\StyleHelper Helper to work with styles
      * @param bool $shouldUseInlineStrings Whether inline or shared strings should be used
+     * @param array $columnsWidth
      * @throws \Box\Spout\Common\Exception\IOException If the sheet data file cannot be opened for writing
      */
-    public function __construct($externalSheet, $worksheetFilesFolder, $sharedStringsHelper, $styleHelper, $shouldUseInlineStrings)
+    public function __construct($externalSheet, $worksheetFilesFolder, $sharedStringsHelper, $styleHelper, $shouldUseInlineStrings, $columnsWidth)
     {
         $this->externalSheet = $externalSheet;
         $this->sharedStringsHelper = $sharedStringsHelper;
@@ -77,6 +81,7 @@ EOD;
         $this->stringHelper = new StringHelper();
 
         $this->worksheetFilePath = $worksheetFilesFolder . '/' . strtolower($this->externalSheet->getName()) . '.xml';
+        $this->columnsWidth = $columnsWidth;
         $this->startSheet();
     }
 
@@ -92,6 +97,19 @@ EOD;
         $this->throwIfSheetFilePointerIsNotAvailable();
 
         fwrite($this->sheetFilePointer, self::SHEET_XML_FILE_HEADER);
+
+        if (!empty($this->columnsWidth)) {
+            $cols = '<cols>';
+            $customWidth = 'customWidth="1"';
+
+            foreach ($this->columnsWidth as $w) {
+                $cols .= '<col min="'.$w['min'].'" max="'.$w['max'].'" width="'.$w['width'].'" '.$customWidth.' />';
+            }
+
+            $cols .= '</cols>';
+            fwrite($this->sheetFilePointer, $cols);
+        }
+
         fwrite($this->sheetFilePointer, '<sheetData>');
     }
 

--- a/src/Spout/Writer/XLSX/Writer.php
+++ b/src/Spout/Writer/XLSX/Writer.php
@@ -30,6 +30,44 @@ class Writer extends AbstractMultiSheetsWriter
     /** @var Internal\Workbook The workbook for the XLSX file */
     protected $book;
 
+    /** @var array Collection of column dimensions */
+    protected $columnsWidth = [];
+
+    /**
+     * Defines column width for one or more columns of the worksheet.
+     *
+     * @param int $width
+     * @param int $min first column affected by this 'column info' record
+     * @param int|null $max last column affected by this 'column info' record
+     * @return Writer
+     */
+    public function setColumnsWidth($width, $min = 1, $max = null)
+    {
+        $columnLength = count($this->columnsWidth);
+
+        if ($columnLength > 0 and $min == 1) {
+            $min = $columnLength + 1;
+        } elseif ($columnLength > 0 and $min > 1) {
+            $min = $columnLength;
+        }
+
+        if ($max === null) {
+            $max = $min;
+        }
+
+        $this->columnsWidth[] = [
+            'width' => $width,
+            'min' => $min,
+            'max' => $max
+        ];
+
+        if ($this->book) {
+            $this->book->setColumnsWidth($this->columnsWidth);
+        }
+
+        return $this;
+    }
+
     /**
      * Sets a custom temporary folder for creating intermediate files/folders.
      * This must be set before opening the writer.
@@ -74,7 +112,7 @@ class Writer extends AbstractMultiSheetsWriter
     {
         if (!$this->book) {
             $tempFolder = ($this->tempFolder) ? : sys_get_temp_dir();
-            $this->book = new Workbook($tempFolder, $this->shouldUseInlineStrings, $this->shouldCreateNewSheetsAutomatically, $this->defaultRowStyle);
+            $this->book = new Workbook($tempFolder, $this->shouldUseInlineStrings, $this->shouldCreateNewSheetsAutomatically, $this->defaultRowStyle, $this->columnsWidth);
             $this->book->addNewSheetAndMakeItCurrent();
         }
     }


### PR DESCRIPTION
Simple way to set column width.

Example:

`<?php
$writer = WriterFactory::create(Type::XLSX);

//Auto Set Columns
$writer->setColumnsWidth(45); //A
$writer->setColumnsWidth(35); //B
$writer->setColumnsWidth(40); //C

//Manual Set Columns
$writer->setColumnsWidth(25, 4, 6); //D to F


$writer->openToBrowser($fileName);
$writer->addRows($multipleRows);
$writer->close();
?>`