### PR TITLE
Force UTF-8 encoding in htmlspecialchars

### DIFF
--- a/src/Spout/Common/Escaper/ODS.php
+++ b/src/Spout/Common/Escaper/ODS.php
@@ -26,13 +26,13 @@ class ODS implements EscaperInterface
             // 'ENT_DISALLOWED' ensures that invalid characters in the given document type are replaced.
             // Otherwise control characters like a vertical tab "\v" will make the XML document unreadable by the XML processor
             // @link https://github.com/box/spout/issues/329
-            $replacedString = htmlspecialchars($string, ENT_NOQUOTES | ENT_DISALLOWED);
+            $replacedString = htmlspecialchars($string, ENT_NOQUOTES | ENT_DISALLOWED, 'UTF-8');
         } else {
             // We are on hhvm or any other engine that does not support ENT_DISALLOWED.
             //
             // @NOTE: Using ENT_NOQUOTES as only XML entities ('<', '>', '&') need to be encoded.
             //        Single and double quotes can be left as is.
-            $escapedString =  htmlspecialchars($string, ENT_NOQUOTES);
+            $escapedString =  htmlspecialchars($string, ENT_NOQUOTES, 'UTF-8');
 
             // control characters values are from 0 to 1F (hex values) in the ASCII table
             // some characters should not be escaped though: "\t", "\r" and "\n".

--- a/src/Spout/Common/Escaper/XLSX.php
+++ b/src/Spout/Common/Escaper/XLSX.php
@@ -44,7 +44,7 @@ class XLSX implements EscaperInterface
         $escapedString = $this->escapeControlCharacters($string);
         // @NOTE: Using ENT_NOQUOTES as only XML entities ('<', '>', '&') need to be encoded.
         //        Single and double quotes can be left as is.
-        $escapedString = htmlspecialchars($escapedString, ENT_NOQUOTES);
+        $escapedString = htmlspecialchars($escapedString, ENT_NOQUOTES, 'UTF-8');
 
         return $escapedString;
     }


### PR DESCRIPTION
Fixes #552 

Forcing the encoding, in case the default encoding is set to something different than UTF-8, which triggers a PHP warning.