### PR TITLE
Remove HHVM workarounds

### DIFF
--- a/src/Spout/Common/Helper/Escaper/ODS.php
+++ b/src/Spout/Common/Helper/Escaper/ODS.php
@@ -9,40 +9,22 @@ namespace Box\Spout\Common\Helper\Escaper;
 class ODS implements EscaperInterface
 {
     /**
-     * Escapes the given string to make it compatible with XLSX
+     * Escapes the given string to make it compatible with ODS
      *
      * @param string $string The string to escape
      * @return string The escaped string
      */
     public function escape($string)
     {
-        if (defined('ENT_DISALLOWED')) {
-            // 'ENT_DISALLOWED' ensures that invalid characters in the given document type are replaced.
-            // Otherwise control characters like a vertical tab "\v" will make the XML document unreadable by the XML processor
-            // @link https://github.com/box/spout/issues/329
-            $replacedString = htmlspecialchars($string, ENT_NOQUOTES | ENT_DISALLOWED);
-        } else {
-            // We are on hhvm or any other engine that does not support ENT_DISALLOWED.
-            //
-            // @NOTE: Using ENT_NOQUOTES as only XML entities ('<', '>', '&') need to be encoded.
-            //        Single and double quotes can be left as is.
-            $escapedString =  htmlspecialchars($string, ENT_NOQUOTES);
-
-            // control characters values are from 0 to 1F (hex values) in the ASCII table
-            // some characters should not be escaped though: "\t", "\r" and "\n".
-            $regexPattern = '[\x00-\x08' .
-                            // skipping "\t" (0x9) and "\n" (0xA)
-                            '\x0B-\x0C' .
-                            // skipping "\r" (0xD)
-                            '\x0E-\x1F]';
-            $replacedString = preg_replace("/$regexPattern/", '�', $escapedString);
-        }
-
-        return $replacedString;
+        // 'ENT_DISALLOWED' ensures that invalid characters in the given document type are replaced.
+        // Otherwise control characters like a vertical tab "\v" will make the XML document unreadable
+        // by the XML processor
+        // @link https://github.com/box/spout/issues/329
+        return htmlspecialchars($string, ENT_NOQUOTES | ENT_DISALLOWED);
     }
 
     /**
-     * Unescapes the given string to make it compatible with XLSX
+     * Unescapes the given string to make it compatible with ODS
      *
      * @param string $string The string to unescape
      * @return string The unescaped string

--- a/src/Spout/Reader/Wrapper/XMLReader.php
+++ b/src/Spout/Reader/Wrapper/XMLReader.php
@@ -27,7 +27,6 @@ class XMLReader extends \XMLReader
 
         // We need to check first that the file we are trying to read really exist because:
         //  - PHP emits a warning when trying to open a file that does not exist.
-        //  - HHVM does not check if file exists within zip file (@link https://github.com/facebook/hhvm/issues/5779)
         if ($this->fileExistsWithinZip($realPathURI)) {
             $wasOpenSuccessful = $this->open($realPathURI, null, LIBXML_NONET);
         }

--- a/tests/Spout/Reader/Wrapper/XMLReaderTest.php
+++ b/tests/Spout/Reader/Wrapper/XMLReaderTest.php
@@ -29,42 +29,6 @@ class XMLReaderTest extends TestCase
     }
 
     /**
-     * Testing a HHVM bug: https://github.com/facebook/hhvm/issues/5779
-     * The associated code in XMLReader::open() can be removed when the issue is fixed (and this test starts failing).
-     * @see XMLReader::open()
-     *
-     * @return void
-     */
-    public function testHHVMStillDoesNotComplainWhenCallingOpenWithFileInsideZipNotExisting()
-    {
-        // Test should only be run on HHVM
-        if ($this->isRunningHHVM()) {
-            $resourcePath = $this->getResourcePath('one_sheet_with_inline_strings.xlsx');
-            $nonExistingXMLFilePath = 'zip://' . $resourcePath . '#path/to/fake/file.xml';
-
-            libxml_clear_errors();
-            $initialUseInternalErrorsSetting = libxml_use_internal_errors(true);
-
-            // using the built-in XMLReader
-            $xmlReader = new \XMLReader();
-            $this->assertNotFalse($xmlReader->open($nonExistingXMLFilePath));
-            $this->assertFalse(libxml_get_last_error());
-
-            libxml_use_internal_errors($initialUseInternalErrorsSetting);
-        } else {
-            $this->markTestSkipped();
-        }
-    }
-
-    /**
-     * @return bool TRUE if running on HHVM, FALSE otherwise
-     */
-    private function isRunningHHVM()
-    {
-        return defined('HHVM_VERSION');
-    }
-
-    /**
      * @return void
      */
     public function testReadShouldThrowExceptionOnError()


### PR DESCRIPTION
* HHVM is removed from the test grid and if we want to use PHP 7.1 features - it will have to go for good.