### PR TITLE
Introduce a Reader range

### DIFF
--- a/src/Spout/Common/Manager/OptionsManagerAbstract.php
+++ b/src/Spout/Common/Manager/OptionsManagerAbstract.php
@@ -7,7 +7,7 @@ namespace Box\Spout\Common\Manager;
  */
 abstract class OptionsManagerAbstract implements OptionsManagerInterface
 {
-    const PREFIX_OPTION = 'OPTION_';
+    public const PREFIX_OPTION = 'OPTION_';
 
     /** @var string[] List of all supported option names */
     private $supportedOptions = [];

--- a/src/Spout/Reader/CSV/Manager/OptionsManager.php
+++ b/src/Spout/Reader/CSV/Manager/OptionsManager.php
@@ -23,6 +23,8 @@ class OptionsManager extends OptionsManagerAbstract
             Options::FIELD_DELIMITER,
             Options::FIELD_ENCLOSURE,
             Options::ENCODING,
+            Options::START_COLUMN,
+            Options::END_COLUMN,
         ];
     }
 

--- a/src/Spout/Reader/Common/Entity/Options.php
+++ b/src/Spout/Reader/Common/Entity/Options.php
@@ -9,15 +9,18 @@ namespace Box\Spout\Reader\Common\Entity;
 abstract class Options
 {
     // Common options
-    const SHOULD_FORMAT_DATES = 'shouldFormatDates';
-    const SHOULD_PRESERVE_EMPTY_ROWS = 'shouldPreserveEmptyRows';
+    public const SHOULD_FORMAT_DATES = 'shouldFormatDates';
+    public const SHOULD_PRESERVE_EMPTY_ROWS = 'shouldPreserveEmptyRows';
+
+    public const START_COLUMN = 'startColumn';
+    public const END_COLUMN = 'endColumn';
 
     // CSV specific options
-    const FIELD_DELIMITER = 'fieldDelimiter';
-    const FIELD_ENCLOSURE = 'fieldEnclosure';
-    const ENCODING = 'encoding';
+    public const FIELD_DELIMITER = 'fieldDelimiter';
+    public const FIELD_ENCLOSURE = 'fieldEnclosure';
+    public const ENCODING = 'encoding';
 
     // XLSX specific options
-    const TEMP_FOLDER = 'tempFolder';
-    const SHOULD_USE_1904_DATES = 'shouldUse1904Dates';
+    public const TEMP_FOLDER = 'tempFolder';
+    public const SHOULD_USE_1904_DATES = 'shouldUse1904Dates';
 }

--- a/src/Spout/Reader/Exception/InvalidReaderOptionValueException.php
+++ b/src/Spout/Reader/Exception/InvalidReaderOptionValueException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Box\Spout\Reader\Exception;
+
+class InvalidReaderOptionValueException extends ReaderException
+{
+}

--- a/src/Spout/Reader/ReaderAbstract.php
+++ b/src/Spout/Reader/ReaderAbstract.php
@@ -28,6 +28,12 @@ abstract class ReaderAbstract implements ReaderInterface
     /** @var OptionsManagerInterface Writer options manager */
     protected $optionsManager;
 
+    /** @var int The column index where the reader should start */
+    protected $startColumnIndex;
+
+    /** @var int The column index where the reader should stop */
+    protected $endColumnIndex;
+
     /**
      * Returns whether stream wrappers are supported
      *
@@ -94,6 +100,28 @@ abstract class ReaderAbstract implements ReaderInterface
     public function setShouldPreserveEmptyRows($shouldPreserveEmptyRows)
     {
         $this->optionsManager->setOption(Options::SHOULD_PRESERVE_EMPTY_ROWS, $shouldPreserveEmptyRows);
+
+        return $this;
+    }
+
+    /**
+     * @param int $startColumnIndex The 0 based start column index
+     * @return ReaderAbstract
+     */
+    public function setStartColumnIndex(int $startColumnIndex) : ReaderAbstract
+    {
+        $this->optionsManager->setOption(Options::START_COLUMN, $startColumnIndex);
+
+        return $this;
+    }
+
+    /**
+     * @param int $endColumnIndex
+     * @return ReaderAbstract
+     */
+    public function setEndColumnIndex(int $endColumnIndex) : ReaderAbstract
+    {
+        $this->optionsManager->setOption(Options::END_COLUMN, $endColumnIndex);
 
         return $this;
     }

--- a/tests/resources/csv/csv_with_headers.csv
+++ b/tests/resources/csv/csv_with_headers.csv
@@ -1,0 +1,5 @@
+"Header-1","Header-2","Header-3",
+"Test-1","Test-2","Test-3",
+"Test-1",,,
+"Test-1","Test-2","Test-3","Test-4"
+,,"Test-3",


### PR DESCRIPTION
This PR introduces  a range for readers like discussed here: https://github.com/box/spout/issues/561#issuecomment-396159208

The range can be defined on a ```Reader``` by setting a zero based start - and end column index. This can be done before or after a reader has been opened.

The  reader will only yield data starting at the start index - and stop reading **after** the end index.

If an end index is provided missing cells are filled with empty values so there is always the same range.

**Given the CSV:**

```CSV
'csv--11', 'csv--12', 'csv--13'
'csv--21', 'csv--22'
'csv--31'
```

```PHP
$reader->open($csv);
$reader->setStartColumnIndex(0);
$reader->setEndColumnIndex(1);
```

**Outputs**:
```
array(3) {
  [0]=>
  array(2) {
    [0]=>
    string(7) "csv--11"
    [1]=>
    string(7) "csv--12"
  }
  [1]=>
  array(2) {
    [0]=>
    string(7) "csv--21"
    [1]=>
    string(7) "csv--22"
  }
  [2]=>
  array(2) {
    [0]=>
    string(7) "csv--31"
    [1]=>
    string(0) ""
  }
}

```

I only did this for the CSV reader for ```RFC``` purposes. 
