### PR TITLE
trying to property of non-object is repaired

### DIFF
--- a/src/Spout/Reader/XLSX/Helper/CellValueFormatter.php
+++ b/src/Spout/Reader/XLSX/Helper/CellValueFormatter.php
@@ -125,6 +125,11 @@ class CellValueFormatter
         // inline strings are formatted this way:
         // <c r="A1" t="inlineStr"><is><t>[INLINE_STRING]</t></is></c>
         $tNode = $node->getElementsByTagName(self::XML_NODE_INLINE_STRING_VALUE)->item(0);
+        
+        if ($tNode === null) {
+            return null;
+        }
+        
         $cellValue = $this->escaper->unescape($tNode->nodeValue);
         return $cellValue;
     }


### PR DESCRIPTION
$tNode can be null if the cell is empty.