### PR TITLE
use expectNotToPerformAssertions

### DIFF
--- a/tests/Spout/Common/Entity/Style/BorderTest.php
+++ b/tests/Spout/Common/Entity/Style/BorderTest.php
@@ -22,7 +22,7 @@ class BorderTest extends TestCase
         $withConstructorParams = new Border([
             new BorderPart(Border::LEFT),
         ]);
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     /**

--- a/tests/Spout/Writer/CSV/WriterTest.php
+++ b/tests/Spout/Writer/CSV/WriterTest.php
@@ -89,7 +89,7 @@ class WriterTest extends TestCase
         $writer->openToFile($resourcePath);
         $writer->close();
         $writer->close(); // This call should not cause any error
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     /**

--- a/tests/Spout/Writer/Common/Entity/SheetTest.php
+++ b/tests/Spout/Writer/Common/Entity/SheetTest.php
@@ -101,7 +101,7 @@ class SheetTest extends TestCase
         $sheet = $this->createSheet(0, 'workbookId1');
         $sheet->setName($customSheetName);
         $sheet->setName($customSheetName);
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     /**
@@ -135,6 +135,6 @@ class SheetTest extends TestCase
 
         $sheet = $this->createSheet(1, 'workbookId3');
         $sheet->setName($customSheetName);
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/Spout/Writer/ODS/WriterTest.php
+++ b/tests/Spout/Writer/ODS/WriterTest.php
@@ -201,7 +201,7 @@ class WriterTest extends TestCase
         $writer->openToFile($resourcePath);
         $writer->close();
         $writer->close(); // This call should not cause any error
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     /**

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -233,7 +233,7 @@ class WriterTest extends TestCase
         $writer->openToFile($resourcePath);
         $writer->close();
         $writer->close(); // This call should not cause any error
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     /**


### PR DESCRIPTION
I introduced ```$this->assertTrue(true);``` hacks a while back to assert something so PHPUnit does not mark these tests as risky. I learned that there is a PHPUnit "way" to do this. by using ```$this->expectNotToPerformAssertions()```.