### PR TITLE
 Allow getting an instance of a reader without Exception 

### DIFF
--- a/src/Spout/Reader/ReaderFactory.php
+++ b/src/Spout/Reader/ReaderFactory.php
@@ -29,20 +29,56 @@ class ReaderFactory
 
         switch ($readerType) {
             case Type::CSV:
-                $reader = new CSV\Reader();
+                $reader = self::createCsvReader();
                 break;
             case Type::XLSX:
-                $reader = new XLSX\Reader();
+                $reader = self::createXlsxReader();
                 break;
             case Type::ODS:
-                $reader = new ODS\Reader();
+                $reader = self::createOdsReader();
                 break;
             default:
                 throw new UnsupportedTypeException('No readers supporting the given type: ' . $readerType);
         }
 
-        $reader->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
+        return $reader;
+    }
+
+    /**
+     * @return CSV\Reader
+     */
+    public static function createCsvReader() {
+        $reader = new CSV\Reader();
+        self::setDefaultGlobalFunctionHelper($reader);
 
         return $reader;
+    }
+
+    /**
+     * @return XLSX\Reader
+     */
+    public static function createXlsxReader() {
+        $reader = new XLSX\Reader();
+        self::setDefaultGlobalFunctionHelper($reader);
+
+        return $reader;
+    }
+
+    /**
+     * @return ODS\Reader
+     */
+    public static function createOdsReader() {
+        $reader = new ODS\Reader();
+        self::setDefaultGlobalFunctionHelper($reader);
+
+        return $reader;
+    }
+
+    /**
+     * @param AbstractReader $reader
+     */
+    private static function setDefaultGlobalFunctionHelper($reader)
+    {
+        $reader->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
     }
 }

--- a/src/Spout/Reader/ReaderFactory.php
+++ b/src/Spout/Reader/ReaderFactory.php
@@ -9,7 +9,7 @@ use Box\Spout\Common\Type;
 /**
  * Class ReaderFactory
  * This factory is used to create readers, based on the type of the file to be read.
- * It supports CSV and XLSX formats.
+ * It supports CSV, ODS and XLSX formats.
  *
  * @package Box\Spout\Reader
  */

--- a/tests/Spout/Reader/ReaderFactoryTest.php
+++ b/tests/Spout/Reader/ReaderFactoryTest.php
@@ -18,4 +18,25 @@ class ReaderFactoryTest extends \PHPUnit_Framework_TestCase
     {
         ReaderFactory::create('unsupportedType');
     }
+
+    public function testCreateCsvReaderShouldProvideACsvReader()
+    {
+        $reader = ReaderFactory::createCsvReader();
+
+        $this->assertInstanceOf('Box\Spout\Reader\CSV\Reader', $reader);
+    }
+
+    public function testCreateXlsxReaderShouldProvideAXlsxReader()
+    {
+        $reader = ReaderFactory::createXlsxReader();
+
+        $this->assertInstanceOf('Box\Spout\Reader\XLSX\Reader', $reader);
+    }
+
+    public function testCreateOdsReaderShouldProvideAOdsReader()
+    {
+        $reader = ReaderFactory::createOdsReader();
+
+        $this->assertInstanceOf('Box\Spout\Reader\ODS\Reader', $reader);
+    }
 }


### PR DESCRIPTION
# Description
When using the Reader factory you have to surround it with a try/catch since it can throw an exception.

If you hard code the Type in the call, there are no chance the exception is ever thrown, so you end up with a block of dead code for catching something that will never happen.

This PR adds dedicated method to retrieve an instance of a reader without having an exception thrown.

# Test
Updated test coverage