### PR TITLE
Current row not available w/o rewinding Iterator

### DIFF
--- a/tests/Spout/Reader/CSV/ReaderTest.php
+++ b/tests/Spout/Reader/CSV/ReaderTest.php
@@ -515,4 +515,31 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $reader->open('unsupported://foobar');
     }
 
+    /**
+     * @return void
+     */
+    public function testReadWithoutCallingRewindFirst()
+    {
+        $resourcePath = $this->getResourcePath('csv_standard.csv');
+
+        /** @var Reader $reader */
+        $reader = ReaderFactory::create(Type::CSV);
+        $reader->open($resourcePath);
+
+        $sheetIterator = $reader->getSheetIterator();
+        /** @var Sheet $sheet */
+        $sheet = $sheetIterator->current();
+
+        /** @var RowIterator $readerIterator */
+        $readerIterator = $sheet->getRowIterator();
+
+        $row = $readerIterator->current();
+
+        $reader->close();
+
+        $expectedRow = ['csv--11', 'csv--12', 'csv--13'];
+
+        $this->assertEquals($expectedRow, $row);
+    }
+
 }


### PR DESCRIPTION
# Description
I ran into this issue while using the library. So here is a unit test illustrating it.

If you don't rewind the iterator after you got it (like a `foreach` would automatically), the current element is not set.

I might add the fix to this issue later, but I wanted you to have a look at this first as it seems the fix will involve quite a lot of changes on the internal of Reader.

# TODO
- [x] Unit test to highlight the issue
- [ ] Fix the issue