### PR TITLE
For PHP 7.1 for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,10 @@
         "branch-alias": {
             "dev-master": "3.1.x-dev"
         }
+    },
+    "config": {
+        "platform": {
+            "php": "7.1"
+        }
     }
-
 }


### PR DESCRIPTION
If local PHP is > 7.1, we still want to download dependencies compatible with PHP 7.1