### PR TITLE
Increase XLSX reading performance

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -23,6 +23,19 @@ class GlobalFunctionsHelper
         return fopen($fileName, $mode);
     }
 
+	/**
+	 * Wrapper around global function fread()
+	 * @see fread()
+	 *
+	 * @param resource $handle
+	 * @param int|null $length
+	 * @return string
+	 */
+	public function fread($handle, $length = null)
+	{
+		return fread($handle, $length);
+	}
+
     /**
      * Wrapper around global function fgets()
      * @see fgets()
@@ -67,12 +80,25 @@ class GlobalFunctionsHelper
      *
      * @param resource $handle
      * @param int $offset
+     * @param int $whence
      * @return int
      */
-    public function fseek($handle, $offset)
+    public function fseek($handle, $offset, $whence = SEEK_SET)
     {
-        return fseek($handle, $offset);
+        return fseek($handle, $offset, $whence);
     }
+
+	/**
+	 * Wrapper around global function ftell()
+	 * @see fseek()
+	 *
+	 * @param resource $handle
+	 * @return bool|int
+	 */
+	public function ftell($handle)
+	{
+		return ftell($handle);
+	}
 
     /**
      * Wrapper around global function fgetcsv()


### PR DESCRIPTION
I have large XLSX file about 1 million rows and 5 columns. First col with unique values and last 2 with the same values. When I try to read this file I saw that performance is not so good. After investigation I found that in FileBasedStrategy::getStringAtIndex() method file with cache is rereading for each row because string index is differ greatly between first and last column of xlsx document.

I have optimized cache by adding additional index file with offset and length for each data and increase reading speed about 4 times (depends on column count).

P.S.

Cant attach whole XLSX file because it is too big. So attached only 300K rows
[test.xlsx](https://github.com/box/spout/files/2764347/test.xlsx)


```php
<?php

use Box\Spout\Reader\Common\Creator\ReaderFactory;
use Box\Spout\Common\Type;

require_once __DIR__ . '/vendor/autoload.php';

$reader = ReaderFactory::create(Type::XLSX);
$reader->open(__DIR__ . '/test.xlsx');

$time = mktime();
foreach ($reader->getSheetIterator() as $sheet) {
	foreach ($sheet->getRowIterator() as $n => $row) {
		if ($n % 100000 == 0) {
			echo "Read $n in " . (mktime() - $time) . " seconds\n";
		}
	}
	break; // no need to read more sheets
}
echo "Read $n in " . (mktime() - $time) . " seconds\n";

$reader->close();
```

**Current realization**
```
php ./test.php
Read 100000 in 14 seconds
Read 200000 in 30 seconds
Read 300000 in 46 seconds
```

**After optimization**
```
php ./test.php
Read 100000 in 44 seconds
Read 200000 in 92 seconds
Read 300000 in 139 seconds
```