### PR TITLE
Add Factory Methods for each type of writers

### DIFF
--- a/src/Spout/Writer/WriterFactory.php
+++ b/src/Spout/Writer/WriterFactory.php
@@ -45,4 +45,34 @@ class WriterFactory
 
         return $writer;
     }
+
+    /**
+     * @return CSV\Writer
+     */
+    public static function createCSVWriter()
+    {
+        $writer = new CSV\Writer();
+        $writer->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
+        return $writer;
+    }
+
+    /**
+     * @return XLSX\Writer
+     */
+    public static function createXLSXWriter()
+    {
+        $writer = new XLSX\Writer();
+        $writer->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
+        return $writer;
+    }
+
+    /**
+     * @return ODS\Writer
+     */
+    public static function createODSWriter()
+    {
+        $writer = new ODS\Writer();
+        $writer->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
+        return $writer;
+    }
 }


### PR DESCRIPTION
Add Factory Methods for each type of writers, to provide better experience with correct PHPDoc in IDE.

The correct factory provides writers of any type with PHPDoc of `WriterInterface`, it is not friendly for IDE to support the instance with its special methods. For example, IDE might warn you when you use `setShouldAddBOM` with a CSV writer if you generate it by the factory. Let IDE know what class you generated might be a kind of choice to refine.

