### PR TITLE
According to https://github.com/box/spout/pull/630#issuecomment-47446…

### DIFF
--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -2,10 +2,23 @@
 
 namespace Box\Spout\Writer\Common\Creator;
 
+use Box\Spout\Common\Creator\HelperFactory;
 use Box\Spout\Common\Entity\Cell;
 use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Entity\Style\Style;
+use Box\Spout\Common\Helper\GlobalFunctionsHelper;
+use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
+use Box\Spout\Writer\CSV\Manager\OptionsManager as CSVOptionsManager;
+use Box\Spout\Writer\CSV\Writer as CSVWriter;
+use Box\Spout\Writer\ODS\Creator\HelperFactory as ODSHelperFactory;
+use Box\Spout\Writer\ODS\Creator\ManagerFactory as ODSManagerFactory;
+use Box\Spout\Writer\ODS\Manager\OptionsManager as ODSOptionsManager;
+use Box\Spout\Writer\ODS\Writer as ODSWriter;
 use Box\Spout\Writer\WriterInterface;
+use Box\Spout\Writer\XLSX\Creator\HelperFactory as XLSXHelperFactory;
+use Box\Spout\Writer\XLSX\Creator\ManagerFactory as XLSXManagerFactory;
+use Box\Spout\Writer\XLSX\Manager\OptionsManager as XLSXOptionsManager;
+use Box\Spout\Writer\XLSX\Writer as XLSXWriter;
 
 /**
  * Class WriterEntityFactory
@@ -30,7 +43,12 @@ class WriterEntityFactory
      */
     public static function createCSVWriter()
     {
-        return (new WriterFactory())->getCSVWriter();
+        $optionsManager = new CSVOptionsManager();
+        $globalFunctionsHelper = new GlobalFunctionsHelper();
+
+        $helperFactory = new HelperFactory();
+
+        return new CSVWriter($optionsManager, $globalFunctionsHelper, $helperFactory);
     }
 
     /**
@@ -38,7 +56,14 @@ class WriterEntityFactory
      */
     public static function createXLSXWriter()
     {
-        return (new WriterFactory())->getXLSXWriter();
+        $styleBuilder = new StyleBuilder();
+        $optionsManager = new XLSXOptionsManager($styleBuilder);
+        $globalFunctionsHelper = new GlobalFunctionsHelper();
+
+        $helperFactory = new XLSXHelperFactory();
+        $managerFactory = new XLSXManagerFactory(new InternalEntityFactory(), $helperFactory);
+
+        return new XLSXWriter($optionsManager, $globalFunctionsHelper, $helperFactory, $managerFactory);
     }
 
     /**
@@ -46,7 +71,14 @@ class WriterEntityFactory
      */
     public static function createODSWriter()
     {
-        return (new WriterFactory())->getODSWriter();
+        $styleBuilder = new StyleBuilder();
+        $optionsManager = new ODSOptionsManager($styleBuilder);
+        $globalFunctionsHelper = new GlobalFunctionsHelper();
+
+        $helperFactory = new ODSHelperFactory();
+        $managerFactory = new ODSManagerFactory(new InternalEntityFactory(), $helperFactory);
+
+        return new ODSWriter($optionsManager, $globalFunctionsHelper, $helperFactory, $managerFactory);
     }
 
 

--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -26,6 +26,31 @@ class WriterEntityFactory
     }
 
     /**
+     * @return \Box\Spout\Writer\CSV\Writer
+     */
+    public static function createCSVWriter()
+    {
+        return (new WriterFactory())->getCSVWriter();
+    }
+
+    /**
+     * @return \Box\Spout\Writer\XLSX\Writer
+     */
+    public static function createXLSXWriter()
+    {
+        return (new WriterFactory())->getXLSXWriter();
+    }
+
+    /**
+     * @return \Box\Spout\Writer\ODS\Writer
+     */
+    public static function createODSWriter()
+    {
+        return (new WriterFactory())->getODSWriter();
+    }
+
+
+    /**
      * @param Cell[] $cells
      * @param Style|null $rowStyle
      * @return Row

--- a/src/Spout/Writer/Common/Creator/WriterFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterFactory.php
@@ -47,7 +47,7 @@ class WriterFactory
     /**
      * @return CSVWriter
      */
-    public function getCSVWriter()
+    private function getCSVWriter()
     {
         $optionsManager = new CSVOptionsManager();
         $globalFunctionsHelper = new GlobalFunctionsHelper();
@@ -60,7 +60,7 @@ class WriterFactory
     /**
      * @return XLSXWriter
      */
-    public function getXLSXWriter()
+    private function getXLSXWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new XLSXOptionsManager($styleBuilder);
@@ -75,7 +75,7 @@ class WriterFactory
     /**
      * @return ODSWriter
      */
-    public function getODSWriter()
+    private function getODSWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new ODSOptionsManager($styleBuilder);

--- a/src/Spout/Writer/Common/Creator/WriterFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterFactory.php
@@ -47,7 +47,7 @@ class WriterFactory
     /**
      * @return CSVWriter
      */
-    private function getCSVWriter()
+    public function getCSVWriter()
     {
         $optionsManager = new CSVOptionsManager();
         $globalFunctionsHelper = new GlobalFunctionsHelper();
@@ -60,7 +60,7 @@ class WriterFactory
     /**
      * @return XLSXWriter
      */
-    private function getXLSXWriter()
+    public function getXLSXWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new XLSXOptionsManager($styleBuilder);
@@ -75,7 +75,7 @@ class WriterFactory
     /**
      * @return ODSWriter
      */
-    private function getODSWriter()
+    public function getODSWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new ODSOptionsManager($styleBuilder);


### PR DESCRIPTION
According to the requirement as

https://github.com/box/spout/pull/630#issuecomment-474463226

Originally PR to master now to dev 3 branch.

> Add Factory Methods for each type of writers, to provide better experience with correct PHPDoc in IDE.

> The correct factory provides writers of any type with PHPDoc of WriterInterface, it is not friendly for IDE to support the instance with its special methods. For example, IDE might warn you when you use setShouldAddBOM with a CSV writer if you generate it by the factory. Let IDE know what class you generated might be a kind of choice to refine.
