### PR TITLE
Add helper functions to create specific readers and writers

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -15,11 +15,14 @@ Finally, **_Spout 3.0 only supports PHP 7.1 and above_**, as other PHP versions 
 
 Reader changes
 --------------
-Creating a reader should now be done through the Reader `ReaderEntityFactory`, instead of using the `ReaderFactory`:
+Creating a reader should now be done through the Reader `ReaderEntityFactory`, instead of using the `ReaderFactory`.
+Also, the `ReaderFactory::create($type)` method was removed and replaced by methods for each reader:
 ```php
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory; // namespace is no longer "Box\Spout\Reader"
 ...
-$reader = ReaderEntityFactory::createReader(Type::XLSX);
+$reader = ReaderEntityFactory::createXLSXReader(); // replaces ReaderFactory::create(Type::XLSX)
+$reader = ReaderEntityFactory::createCSVReader();  // replaces ReaderFactory::create(Type::CSV)
+$reader = ReaderEntityFactory::createODSReader();  // replaces ReaderFactory::create(Type::ODS)
 ```
 
 When iterating over the spreadsheet rows, Spout now returns `Row` objects, instead of an array containing row values. Accessing the row values should now be done this way:
@@ -37,11 +40,15 @@ foreach ($reader->getSheetIterator() as $sheet) {
 
 Writer changes
 --------------
-Writer creation follows the same change as the reader. It should now be done through the Writer `WriterEntityFactory`, instead of using the `WriterFactory`:
+Writer creation follows the same change as the reader. It should now be done through the Writer `WriterEntityFactory`, instead of using the `WriterFactory`.
+Also, the `WriterFactory::create($type)` method was removed and replaced by methods for each writer:
+
 ```php
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory; // namespace is no longer "Box\Spout\Writer"
 ...
-$writer = WriterEntityFactory::createWriter(Type::ODS);
+$writer = WriterEntityFactory::createXLSXWriter(); // replaces WriterFactory::create(Type::XLSX)
+$writer = WriterEntityFactory::createCSVWriter();  // replaces WriterFactory::create(Type::CSV)
+$writer = WriterEntityFactory::createODSWriter();  // replaces WriterFactory::create(Type::ODS)
 ```
 
 Adding rows is also done differently: instead of passing an array, the writer now takes in a `Row` object (or an array of `Row`). Creating such objects can easily be done this way:

--- a/docs/_pages/documentation.md
+++ b/docs/_pages/documentation.md
@@ -44,9 +44,8 @@ It is possible to change the behavior of the writers when the maximum number of 
 ```php
 
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
-use Box\Spout\Common\Type;
 
-$writer = WriterEntityFactory::createWriter(Type::ODS);
+$writer = WriterEntityFactory::createODSWriter();
 $writer->setShouldCreateNewSheetsAutomatically(true); // default value
 $writer->setShouldCreateNewSheetsAutomatically(false); // will stop writing new data when limit is reached
 ```
@@ -57,9 +56,8 @@ Processing XLSX and ODS files requires temporary files to be created. By default
 
 ```php
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
-use Box\Spout\Common\Type;
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->setTempFolder($customTempFolderPath);
 ```
 
@@ -73,9 +71,8 @@ In order to keep the memory usage really low, {{ site.spout_html }} does not de-
 
 ```php
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
-use Box\Spout\Common\Type;
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->setShouldUseInlineStrings(true); // default (and recommended) value
 $writer->setShouldUseInlineStrings(false); // will use shared strings
 ```
@@ -91,9 +88,8 @@ It is possible to change this behavior and have a formatted date returned instea
 
 ```php
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
-use Box\Spout\Common\Type;
 
-$reader = ReaderEntityFactory::createReader(Type::XLSX);
+$reader = ReaderEntityFactory::createXLSXReader();
 $reader->setShouldFormatDates(false); // default value
 $reader->setShouldFormatDates(true); // will return formatted dates
 ```
@@ -137,12 +133,11 @@ For fonts and alignments, {{ site.spout_html }} does not support all the possibl
 It is possible to apply some formatting options to a row. In this case, all cells of the row will have the same style:
 
 ```php
-use Box\Spout\Common\Type;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
 use Box\Spout\Common\Entity\Style\Color;
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->openToFile($filePath);
 
 /** Create a style with the StyleBuilder */
@@ -165,7 +160,6 @@ $writer->close();
 Adding borders to a row requires a ```Border``` object.
 
 ```php
-use Box\Spout\Common\Type;
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
 use Box\Spout\Common\Entity\Style\Color;
@@ -180,7 +174,7 @@ $style = (new StyleBuilder())
     ->setBorder($border)
     ->build();
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->openToFile($filePath);
 
 $cells = WriterEntityFactory::createCell('Border Bottom Green Thin Dashed');
@@ -202,7 +196,6 @@ The styles applied to a specific cell will override any parent styles if present
 Example:
 
 ```php
-use Box\Spout\Common\Type;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
@@ -211,7 +204,7 @@ $defaultStyle = (new StyleBuilder())
     ->setFontSize(8)
     ->build();
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->setDefaultRowStyle($defaultStyle)
     ->openToFile($filePath);
 
@@ -252,7 +245,7 @@ $defaultStyle = (new StyleBuilder())
                 ->setFontSize(11)
                 ->build();
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
+$writer = WriterEntityFactory::createXLSXWriter();
 $writer->setDefaultRowStyle($defaultStyle)
        ->openToFile($filePath);
 ```

--- a/docs/_pages/getting-started.md
+++ b/docs/_pages/getting-started.md
@@ -68,16 +68,14 @@ $reader->close();
 If there are multiple sheets in the file, the reader will read all of them sequentially.
 
 
-Note that {{ site.spout_html }} guesses the reader type based on the file extension. If the extension is not standard (`.csv`, `.ods`, `.xlsx` _- lower/uppercase_), the reader type needs to be specified:
+Note that {{ site.spout_html }} guesses the reader type based on the file extension. If the extension is not standard (`.csv`, `.ods`, `.xlsx` _- lower/uppercase_), a specific reader can be created directly:
 
 ```php
-
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
-use Box\Spout\Common\Type;
 
-$reader = ReaderEntityFactory::createReader(Type::XLSX); // for XLSX files
-// $reader = ReaderEntityFactory::createReader(Type::ODS); // for ODS files
-// $reader = ReaderEntityFactory::createReader(Type::CSV); // for CSV files
+$reader = ReaderEntityFactory::createXLSXReader();
+// $reader = ReaderEntityFactory::createODSReader();
+// $reader = ReaderEntityFactory::createCSVReader();
 ```
 
 ### Writer
@@ -124,9 +122,9 @@ Similar to the reader, if the file extension of the file to be written is not st
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Common\Entity\Row;
 
-$writer = WriterEntityFactory::createWriter(Type::XLSX);
-// $writer = WriterEntityFactory::createWriter(Type::ODS);
-// $writer = WriterEntityFactory::createWriter(Type::CSV);
+$writer = WriterEntityFactory::createXLSXWriter();
+// $writer = WriterEntityFactory::createODSWriter();
+// $writer = WriterEntityFactory::createCSVWriter();
 ```
 
 For XLSX and ODS files, the number of rows per sheet is limited to *1,048,576*. By default, once this limit is reached, the writer will automatically create a new sheet and continue writing data into it.

--- a/docs/_pages/guides/3-read-data-from-specific-sheet.md
+++ b/docs/_pages/guides/3-read-data-from-specific-sheet.md
@@ -12,10 +12,9 @@ Even though a spreadsheet contains multiple sheets, you may be interested in rea
 ```php
 <?php
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 
-$reader = ReaderEntityFactory::createReader(Type::XLSX);
+$reader = ReaderEntityFactory::createXLSXReader();
 $reader->open($filePath);
 
 foreach ($reader->getSheetIterator() as $sheet) {
@@ -36,10 +35,9 @@ $reader->close();
 ```php
 <?php
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 
-$reader = ReaderEntityFactory::createReader(Type::XLSX);
+$reader = ReaderEntityFactory::createXLSXReader();
 $reader->open($filePath);
 
 foreach ($reader->getSheetIterator() as $sheet) {

--- a/docs/_pages/guides/4-symfony-stream-content-large-spreadsheet.md
+++ b/docs/_pages/guides/4-symfony-stream-content-large-spreadsheet.md
@@ -77,7 +77,7 @@ class MyStreamController extends Controller
         // a callback function to retrieve data chunks.
         $response->setCallback(function() use ($filePath) {
             // Same code goes inside the callback.
-            $reader = ReaderEntityFactory::createReader(Type::XLSX);
+            $reader = ReaderEntityFactory::createXLSXReader();
             $reader->open($filePath);
 
             $i = 0;

--- a/src/Spout/Reader/Common/Creator/ReaderEntityFactory.php
+++ b/src/Spout/Reader/Common/Creator/ReaderEntityFactory.php
@@ -2,6 +2,8 @@
 
 namespace Box\Spout\Reader\Common\Creator;
 
+use Box\Spout\Common\Exception\UnsupportedTypeException;
+use Box\Spout\Common\Type;
 use Box\Spout\Reader\ReaderInterface;
 
 /**
@@ -11,27 +13,56 @@ use Box\Spout\Reader\ReaderInterface;
 class ReaderEntityFactory
 {
     /**
-     * This creates an instance of the appropriate reader, given the type of the file to be read
-     *
-     * @param string $readerType Type of the reader to instantiate
-     * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
-     * @return ReaderInterface
-     */
-    public static function createReader($readerType)
-    {
-        return ReaderFactory::create($readerType);
-    }
-
-    /**
      * Creates a reader by file extension
      *
      * @param string $path The path to the spreadsheet file. Supported extensions are .csv, .ods and .xlsx
-     * @throws \Box\Spout\Common\Exception\IOException
      * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
      * @return ReaderInterface
      */
     public static function createReaderFromFile(string $path)
     {
         return ReaderFactory::createFromFile($path);
+    }
+
+    /**
+     * This creates an instance of a CSV reader
+     *
+     * @return \Box\Spout\Reader\CSV\Reader
+     */
+    public static function createCSVReader()
+    {
+        try {
+            return ReaderFactory::createFromType(Type::CSV);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
+    }
+
+    /**
+     * This creates an instance of a XLSX reader
+     *
+     * @return \Box\Spout\Reader\XLSX\Reader
+     */
+    public static function createXLSXReader()
+    {
+        try {
+            return ReaderFactory::createFromType(Type::XLSX);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
+    }
+
+    /**
+     * This creates an instance of a ODS reader
+     *
+     * @return \Box\Spout\Reader\ODS\Reader
+     */
+    public static function createODSReader()
+    {
+        try {
+            return ReaderFactory::createFromType(Type::ODS);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
     }
 }

--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -5,6 +5,8 @@ namespace Box\Spout\Writer\Common\Creator;
 use Box\Spout\Common\Entity\Cell;
 use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Entity\Style\Style;
+use Box\Spout\Common\Exception\UnsupportedTypeException;
+use Box\Spout\Common\Type;
 use Box\Spout\Writer\WriterInterface;
 
 /**
@@ -22,20 +24,61 @@ class WriterEntityFactory
      */
     public static function createWriter($writerType)
     {
-        return WriterFactory::create($writerType);
+        return WriterFactory::createFromType($writerType);
     }
 
     /**
      * This creates an instance of the appropriate writer, given the extension of the file to be written
      *
      * @param string $path The path to the spreadsheet file. Supported extensions are .csv, .ods and .xlsx
-     * @throws \Box\Spout\Common\Exception\IOException
      * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
      * @return WriterInterface
      */
     public static function createWriterFromFile(string $path)
     {
         return WriterFactory::createFromFile($path);
+    }
+
+    /**
+     * This creates an instance of a CSV writer
+     *
+     * @return \Box\Spout\Writer\CSV\Writer
+     */
+    public static function createCSVWriter()
+    {
+        try {
+            return WriterFactory::createFromType(Type::CSV);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
+    }
+
+    /**
+     * This creates an instance of a XLSX writer
+     *
+     * @return \Box\Spout\Writer\XLSX\Writer
+     */
+    public static function createXLSXWriter()
+    {
+        try {
+            return WriterFactory::createFromType(Type::XLSX);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
+    }
+
+    /**
+     * This creates an instance of a ODS writer
+     *
+     * @return \Box\Spout\Writer\ODS\Writer
+     */
+    public static function createODSWriter()
+    {
+        try {
+            return WriterFactory::createFromType(Type::ODS);
+        } catch (UnsupportedTypeException $e) {
+            // should never happen
+        }
     }
 
     /**

--- a/src/Spout/Writer/Common/Creator/WriterFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterFactory.php
@@ -3,7 +3,6 @@
 namespace Box\Spout\Writer\Common\Creator;
 
 use Box\Spout\Common\Creator\HelperFactory;
-use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Exception\UnsupportedTypeException;
 use Box\Spout\Common\Helper\GlobalFunctionsHelper;
 use Box\Spout\Common\Type;
@@ -28,65 +27,41 @@ use Box\Spout\Writer\XLSX\Writer as XLSXWriter;
 class WriterFactory
 {
     /**
-     * Map file extensions to reader types
-     * @var array
-     */
-    private static $extensionReaderMap = [
-        'csv' => Type::CSV,
-        'ods' => Type::ODS,
-        'xlsx' => Type::XLSX,
-    ];
-
-    /**
-     * This creates an instance of the appropriate writer, given the type of the file to be read
+     * This creates an instance of the appropriate writer, given the extension of the file to be written
      *
-     * @param  string $writerType Type of the writer to instantiate
+     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
      * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
      * @return WriterInterface
      */
-    public static function create($writerType)
+    public static function createFromFile(string $path)
+    {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        return self::createFromType($extension);
+    }
+
+    /**
+     * This creates an instance of the appropriate writer, given the type of the file to be written
+     *
+     * @param string $writerType Type of the writer to instantiate
+     * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
+     * @return WriterInterface
+     */
+    public static function createFromType($writerType)
     {
         switch ($writerType) {
-            case Type::CSV: return self::getCSVWriter();
-            case Type::XLSX: return self::getXLSXWriter();
-            case Type::ODS: return self::getODSWriter();
+            case Type::CSV: return self::createCSVWriter();
+            case Type::XLSX: return self::createXLSXWriter();
+            case Type::ODS: return self::createODSWriter();
             default:
                 throw new UnsupportedTypeException('No writers supporting the given type: ' . $writerType);
         }
     }
 
     /**
-     * This creates an instance of the appropriate writer, given the extension of the file to be written
-     *
-     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
-     * @throws \Box\Spout\Common\Exception\IOException
-     * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
-     * @return WriterInterface
-     */
-    public static function createFromFile(string $path)
-    {
-        if (!is_file($path)) {
-            throw new IOException(
-                sprintf('Could not open "%s" for reading! File does not exist.', $path)
-            );
-        }
-
-        $ext = pathinfo($path, PATHINFO_EXTENSION);
-        $ext = strtolower($ext);
-        $readerType = self::$extensionReaderMap[$ext] ?? null;
-        if ($readerType === null) {
-            throw new UnsupportedTypeException(
-                sprintf('No readers supporting the file extension "%s".', $ext)
-            );
-        }
-
-        return self::create($readerType);
-    }
-
-    /**
      * @return CSVWriter
      */
-    private static function getCSVWriter()
+    private static function createCSVWriter()
     {
         $optionsManager = new CSVOptionsManager();
         $globalFunctionsHelper = new GlobalFunctionsHelper();
@@ -99,7 +74,7 @@ class WriterFactory
     /**
      * @return XLSXWriter
      */
-    private static function getXLSXWriter()
+    private static function createXLSXWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new XLSXOptionsManager($styleBuilder);
@@ -114,7 +89,7 @@ class WriterFactory
     /**
      * @return ODSWriter
      */
-    private static function getODSWriter()
+    private static function createODSWriter()
     {
         $styleBuilder = new StyleBuilder();
         $optionsManager = new ODSOptionsManager($styleBuilder);

--- a/tests/Spout/Reader/CSV/ReaderPerfTest.php
+++ b/tests/Spout/Reader/CSV/ReaderPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\CSV;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +35,7 @@ class ReaderPerfTest extends TestCase
         $fileName = 'csv_with_one_million_rows.csv';
         $resourcePath = $this->getResourcePath($fileName);
 
-        $reader = ReaderEntityFactory::createReader(Type::CSV);
+        $reader = ReaderEntityFactory::createCSVReader();
         $reader->open($resourcePath);
 
         $numReadRows = 0;

--- a/tests/Spout/Reader/CSV/SheetTest.php
+++ b/tests/Spout/Reader/CSV/SheetTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\CSV;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +32,7 @@ class SheetTest extends TestCase
     private function openFileAndReturnSheet($fileName)
     {
         $resourcePath = $this->getResourcePath($fileName);
-        $reader = ReaderEntityFactory::createReader(Type::CSV);
+        $reader = ReaderEntityFactory::createCSVReader();
         $reader->open($resourcePath);
 
         $sheet = $reader->getSheetIterator()->current();

--- a/tests/Spout/Reader/Common/Creator/ReaderEntityFactoryTest.php
+++ b/tests/Spout/Reader/Common/Creator/ReaderEntityFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\Common\Creator;
 
-use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Exception\UnsupportedTypeException;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -58,16 +57,16 @@ class ReaderEntityFactoryTest extends TestCase
     {
         $this->expectException(UnsupportedTypeException::class);
         $invalid = $this->getResourcePath('test_unsupported_file_type.other');
-        $reader = ReaderEntityFactory::createReaderFromFile($invalid);
+        ReaderEntityFactory::createReaderFromFile($invalid);
     }
 
     /**
      * @return void
      */
-    public function testCreateFromFileMissing()
+    public function testCreateFromFileMissingShouldWork()
     {
-        $this->expectException(IOException::class);
-        $invalid = 'thereisnosuchfile.ext';
-        $reader = ReaderEntityFactory::createReaderFromFile($invalid);
+        $notExistingFile = 'thereisnosuchfile.csv';
+        $reader = ReaderEntityFactory::createReaderFromFile($notExistingFile);
+        $this->assertInstanceOf('Box\Spout\Reader\CSV\Reader', $reader);
     }
 }

--- a/tests/Spout/Reader/Common/Creator/ReaderFactoryTest.php
+++ b/tests/Spout/Reader/Common/Creator/ReaderFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\Common\Creator;
 
-use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Exception\UnsupportedTypeException;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -61,7 +60,7 @@ class ReaderFactoryTest extends TestCase
     {
         $this->expectException(UnsupportedTypeException::class);
 
-        ReaderFactory::create('unsupportedType');
+        ReaderFactory::createFromType('unsupportedType');
     }
 
     /**
@@ -77,10 +76,10 @@ class ReaderFactoryTest extends TestCase
     /**
      * @return void
      */
-    public function testCreateFromFileMissing()
+    public function testCreateFromFileMissingShouldWork()
     {
-        $this->expectException(IOException::class);
-        $invalid = 'thereisnosuchfile.ext';
-        ReaderFactory::createFromFile($invalid);
+        $notExistingFile = 'thereisnosuchfile.csv';
+        $reader = ReaderEntityFactory::createReaderFromFile($notExistingFile);
+        $this->assertInstanceOf('Box\Spout\Reader\CSV\Reader', $reader);
     }
 }

--- a/tests/Spout/Reader/ODS/ReaderPerfTest.php
+++ b/tests/Spout/Reader/ODS/ReaderPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\ODS;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +35,7 @@ class ReaderPerfTest extends Testcase
         $fileName = 'ods_with_one_million_rows.ods';
         $resourcePath = $this->getResourcePath($fileName);
 
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open($resourcePath);
 
         $numReadRows = 0;

--- a/tests/Spout/Reader/ODS/ReaderTest.php
+++ b/tests/Spout/Reader/ODS/ReaderTest.php
@@ -3,7 +3,6 @@
 namespace Box\Spout\Reader\ODS;
 
 use Box\Spout\Common\Exception\IOException;
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\Reader\Exception\IteratorNotRewindableException;
 use Box\Spout\TestUsingResource;
@@ -354,7 +353,7 @@ class ReaderTest extends TestCase
         $this->expectException(IteratorNotRewindableException::class);
 
         $resourcePath = $this->getResourcePath('one_sheet_with_strings.ods');
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open($resourcePath);
 
         foreach ($reader->getSheetIterator() as $sheet) {
@@ -378,8 +377,7 @@ class ReaderTest extends TestCase
         $allRows = [];
         $resourcePath = $this->getResourcePath('two_sheets_with_strings.ods');
 
-        /** @var Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open($resourcePath);
 
         foreach ($reader->getSheetIterator() as $sheet) {
@@ -422,8 +420,7 @@ class ReaderTest extends TestCase
     {
         $this->expectException(IOException::class);
 
-        /** @var \Box\Spout\Reader\ODS\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open('unsupported://foobar');
     }
 
@@ -434,8 +431,7 @@ class ReaderTest extends TestCase
     {
         $this->expectException(IOException::class);
 
-        /** @var \Box\Spout\Reader\ODS\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open('php://memory');
     }
 
@@ -530,8 +526,7 @@ class ReaderTest extends TestCase
         $allRows = [];
         $resourcePath = $this->getResourcePath($fileName);
 
-        /** @var \Box\Spout\Reader\ODS\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->setShouldFormatDates($shouldFormatDates);
         $reader->setShouldPreserveEmptyRows($shouldPreserveEmptyRows);
         $reader->open($resourcePath);

--- a/tests/Spout/Reader/ODS/SheetTest.php
+++ b/tests/Spout/Reader/ODS/SheetTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\ODS;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -61,7 +60,7 @@ class SheetTest extends TestCase
     private function openFileAndReturnSheets($fileName)
     {
         $resourcePath = $this->getResourcePath($fileName);
-        $reader = ReaderEntityFactory::createReader(Type::ODS);
+        $reader = ReaderEntityFactory::createODSReader();
         $reader->open($resourcePath);
 
         $sheets = [];

--- a/tests/Spout/Reader/XLSX/ReaderPerfTest.php
+++ b/tests/Spout/Reader/XLSX/ReaderPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\XLSX;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +49,7 @@ class ReaderPerfTest extends TestCase
         $fileName = ($shouldUseInlineStrings) ? 'xlsx_with_300k_rows_and_inline_strings.xlsx' : 'xlsx_with_300k_rows_and_shared_strings.xlsx';
         $resourcePath = $this->getResourcePath($fileName);
 
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open($resourcePath);
 
         $numReadRows = 0;

--- a/tests/Spout/Reader/XLSX/ReaderTest.php
+++ b/tests/Spout/Reader/XLSX/ReaderTest.php
@@ -3,7 +3,6 @@
 namespace Box\Spout\Reader\XLSX;
 
 use Box\Spout\Common\Exception\IOException;
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -570,7 +569,7 @@ class ReaderTest extends TestCase
         $allRows = [];
         $resourcePath = $this->getResourcePath('two_sheets_with_inline_strings.xlsx');
 
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open($resourcePath);
 
         foreach ($reader->getSheetIterator() as $sheet) {
@@ -623,8 +622,7 @@ class ReaderTest extends TestCase
     {
         $this->expectException(IOException::class);
 
-        /** @var \Box\Spout\Reader\XLSX\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open('unsupported://foobar');
     }
 
@@ -635,8 +633,7 @@ class ReaderTest extends TestCase
     {
         $this->expectException(IOException::class);
 
-        /** @var \Box\Spout\Reader\XLSX\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open('php://memory');
     }
 
@@ -700,8 +697,7 @@ class ReaderTest extends TestCase
         $allRows = [];
         $resourcePath = $this->getResourcePath($fileName);
 
-        /** @var \Box\Spout\Reader\XLSX\Reader $reader */
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->setShouldFormatDates($shouldFormatDates);
         $reader->setShouldPreserveEmptyRows($shouldPreserveEmptyRows);
         $reader->open($resourcePath);

--- a/tests/Spout/Reader/XLSX/SheetTest.php
+++ b/tests/Spout/Reader/XLSX/SheetTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Reader\XLSX;
 
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\TestUsingResource;
 use PHPUnit\Framework\TestCase;
@@ -49,7 +48,7 @@ class SheetTest extends TestCase
     private function openFileAndReturnSheets($fileName)
     {
         $resourcePath = $this->getResourcePath($fileName);
-        $reader = ReaderEntityFactory::createReader(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open($resourcePath);
 
         $sheets = [];

--- a/tests/Spout/Writer/CSV/WriterPerfTest.php
+++ b/tests/Spout/Writer/CSV/WriterPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Writer\CSV;
 
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +37,7 @@ class WriterPerfTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->openToFile($resourcePath);
 
         for ($i = 1; $i <= $numRows; $i++) {

--- a/tests/Spout/Writer/CSV/WriterTest.php
+++ b/tests/Spout/Writer/CSV/WriterTest.php
@@ -6,7 +6,6 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Exception\InvalidArgumentException;
 use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Helper\EncodingHelper;
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Writer\Exception\WriterNotOpenedException;
@@ -32,7 +31,7 @@ class WriterTest extends TestCase
         $this->createUnwritableFolderIfNeeded();
         $filePath = $this->getGeneratedUnwritableResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         @$writer->openToFile($filePath);
         $writer->addRow($this->createRowFromValues(['csv--11', 'csv--12']));
         $writer->close();
@@ -45,7 +44,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->addRow($this->createRowFromValues(['csv--11', 'csv--12']));
         $writer->close();
     }
@@ -57,7 +56,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->addRow($this->createRowFromValues(['csv--11', 'csv--12']));
         $writer->close();
     }
@@ -69,7 +68,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->addRows([['csv--11', 'csv--12']]);
         $writer->close();
     }
@@ -83,7 +82,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->close(); // This call should not cause any error
 
         $writer->openToFile($resourcePath);
@@ -201,8 +200,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\CSV\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::CSV);
+        $writer = WriterEntityFactory::createCSVWriter();
         $writer->setFieldDelimiter($fieldDelimiter);
         $writer->setFieldEnclosure($fieldEnclosure);
         $writer->setShouldAddBOM($shouldAddBOM);

--- a/tests/Spout/Writer/Common/Creator/WriterFactoryTest.php
+++ b/tests/Spout/Writer/Common/Creator/WriterFactoryTest.php
@@ -60,7 +60,7 @@ class WriterFactoryTest extends TestCase
     {
         $this->expectException(UnsupportedTypeException::class);
 
-        WriterFactory::create('unsupportedType');
+        WriterFactory::createFromType('unsupportedType');
     }
 
     /**

--- a/tests/Spout/Writer/ODS/SheetTest.php
+++ b/tests/Spout/Writer/ODS/SheetTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Writer\ODS;
 
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Writer\Common\Entity\Sheet;
@@ -65,8 +64,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $customSheetName = 'Sheet name';
@@ -104,8 +102,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $sheet = $writer->getCurrentSheet();
@@ -124,8 +121,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $writer->addRow($this->createRowFromValues(['ods--sheet1--11', 'ods--sheet1--12']));
@@ -146,8 +142,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $sheet = $writer->getCurrentSheet();

--- a/tests/Spout/Writer/ODS/WriterPerfTest.php
+++ b/tests/Spout/Writer/ODS/WriterPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Writer\ODS;
 
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use PHPUnit\Framework\TestCase;
@@ -38,8 +37,7 @@ class WriterPerfTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->setShouldCreateNewSheetsAutomatically(true);
 
         $writer->openToFile($resourcePath);

--- a/tests/Spout/Writer/ODS/WriterTest.php
+++ b/tests/Spout/Writer/ODS/WriterTest.php
@@ -6,7 +6,6 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Exception\InvalidArgumentException;
 use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Exception\SpoutException;
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Wrapper\XMLReader;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
@@ -34,7 +33,7 @@ class WriterTest extends TestCase
         $this->createUnwritableFolderIfNeeded();
         $filePath = $this->getGeneratedUnwritableResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         @$writer->openToFile($filePath);
     }
 
@@ -45,7 +44,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->addRow($this->createRowFromValues(['ods--11', 'ods--12']));
     }
 
@@ -56,7 +55,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->addRows([$this->createRowFromValues(['ods--11', 'ods--12'])]);
     }
 
@@ -70,8 +69,7 @@ class WriterTest extends TestCase
         $fileName = 'file_that_wont_be_written.ods';
         $filePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($filePath);
 
         $writer->setTempFolder('');
@@ -87,8 +85,7 @@ class WriterTest extends TestCase
         $fileName = 'file_that_wont_be_written.ods';
         $filePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($filePath);
 
         $writer->setShouldCreateNewSheetsAutomatically(true);
@@ -126,8 +123,7 @@ class WriterTest extends TestCase
         $this->recreateTempFolder();
         $tempFolderPath = $this->getTempFolderPath();
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->setTempFolder($tempFolderPath);
         $writer->openToFile($resourcePath);
 
@@ -151,8 +147,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
         $writer->addNewSheetAndMakeItCurrent();
         $writer->close();
@@ -171,8 +166,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $writer->addNewSheetAndMakeItCurrent();
@@ -195,7 +189,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->close(); // This call should not cause any error
 
         $writer->openToFile($resourcePath);
@@ -349,8 +343,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->openToFile($resourcePath);
 
         $writer->addRows($dataRowsSheet1);
@@ -485,8 +478,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->setShouldCreateNewSheetsAutomatically($shouldCreateSheetsAutomatically);
 
         $writer->openToFile($resourcePath);
@@ -508,8 +500,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->setShouldCreateNewSheetsAutomatically($shouldCreateSheetsAutomatically);
 
         $writer->openToFile($resourcePath);

--- a/tests/Spout/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/ODS/WriterWithStyleTest.php
@@ -6,7 +6,6 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Common\Entity\Style\Style;
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Wrapper\XMLReader;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
@@ -42,7 +41,7 @@ class WriterWithStyleTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->addRow($this->createStyledRowFromValues(['ods--11', 'ods--12'], $this->defaultStyle));
     }
 
@@ -53,7 +52,7 @@ class WriterWithStyleTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->addRow($this->createStyledRowFromValues(['ods--11', 'ods--12'], $this->defaultStyle));
     }
 
@@ -346,8 +345,7 @@ class WriterWithStyleTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
 
         $writer->openToFile($resourcePath);
         $writer->addRows($allRows);
@@ -367,8 +365,7 @@ class WriterWithStyleTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\ODS\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::ODS);
+        $writer = WriterEntityFactory::createODSWriter();
         $writer->setDefaultRowStyle($defaultStyle);
 
         $writer->openToFile($resourcePath);

--- a/tests/Spout/Writer/XLSX/SheetTest.php
+++ b/tests/Spout/Writer/XLSX/SheetTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Writer\XLSX;
 
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Writer\Common\Entity\Sheet;
@@ -65,8 +64,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
 
         $customSheetName = 'Sheet name';
@@ -104,8 +102,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
 
         $sheet = $writer->getCurrentSheet();
@@ -126,8 +123,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
 
         $writer->addRow($this->createRowFromValues(['xlsx--sheet1--11', 'xlsx--sheet1--12']));
@@ -148,8 +144,7 @@ class SheetTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
 
         $sheet = $writer->getCurrentSheet();

--- a/tests/Spout/Writer/XLSX/WriterPerfTest.php
+++ b/tests/Spout/Writer/XLSX/WriterPerfTest.php
@@ -2,7 +2,6 @@
 
 namespace Box\Spout\Writer\XLSX;
 
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use PHPUnit\Framework\TestCase;
@@ -52,8 +51,7 @@ class WriterPerfTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings($shouldUseInlineStrings);
         $writer->setShouldCreateNewSheetsAutomatically(true);
 

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -6,7 +6,6 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Exception\InvalidArgumentException;
 use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Exception\SpoutException;
-use Box\Spout\Common\Type;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
 use Box\Spout\Writer\Exception\WriterAlreadyOpenedException;
@@ -34,7 +33,7 @@ class WriterTest extends TestCase
         $this->createUnwritableFolderIfNeeded();
         $filePath = $this->getGeneratedUnwritableResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         @$writer->openToFile($filePath);
     }
 
@@ -45,7 +44,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->addRow($this->createRowFromValues(['xlsx--11', 'xlsx--12']));
     }
 
@@ -56,7 +55,7 @@ class WriterTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->addRows($this->createRowsFromValues([['xlsx--11', 'xlsx--12']]));
     }
 
@@ -70,8 +69,7 @@ class WriterTest extends TestCase
         $fileName = 'file_that_wont_be_written.xlsx';
         $filePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($filePath);
 
         $writer->setTempFolder('');
@@ -87,8 +85,7 @@ class WriterTest extends TestCase
         $fileName = 'file_that_wont_be_written.xlsx';
         $filePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($filePath);
 
         $writer->setShouldUseInlineStrings(true);
@@ -104,8 +101,7 @@ class WriterTest extends TestCase
         $fileName = 'file_that_wont_be_written.xlsx';
         $filePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($filePath);
 
         $writer->setShouldCreateNewSheetsAutomatically(true);
@@ -158,8 +154,7 @@ class WriterTest extends TestCase
         $this->recreateTempFolder();
         $tempFolderPath = $this->getTempFolderPath();
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setTempFolder($tempFolderPath);
         $writer->openToFile($resourcePath);
 
@@ -183,8 +178,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
         $writer->addNewSheetAndMakeItCurrent();
         $writer->close();
@@ -203,8 +197,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->openToFile($resourcePath);
 
         $writer->addNewSheetAndMakeItCurrent();
@@ -227,7 +220,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->close(); // This call should not cause any error
 
         $writer->openToFile($resourcePath);
@@ -404,8 +397,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings(true);
 
         $writer->openToFile($resourcePath);
@@ -544,8 +536,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings($shouldUseInlineStrings);
         $writer->setShouldCreateNewSheetsAutomatically($shouldCreateSheetsAutomatically);
 
@@ -569,8 +560,7 @@ class WriterTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings($shouldUseInlineStrings);
         $writer->setShouldCreateNewSheetsAutomatically($shouldCreateSheetsAutomatically);
 

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -2,12 +2,10 @@
 
 namespace Box\Spout\Writer\XLSX;
 
-use Box\Spout\Common\Entity\Cell;
 use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Common\Entity\Style\Style;
-use Box\Spout\Common\Type;
 use Box\Spout\Reader\Wrapper\XMLReader;
 use Box\Spout\TestUsingResource;
 use Box\Spout\Writer\Common\Creator\Style\BorderBuilder;
@@ -45,7 +43,7 @@ class WriterWithStyleTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->addRow($this->createStyledRowFromValues(['xlsx--11', 'xlsx--12'], $this->defaultStyle));
     }
 
@@ -56,7 +54,7 @@ class WriterWithStyleTest extends TestCase
     {
         $this->expectException(WriterNotOpenedException::class);
 
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->addRow($this->createStyledRowFromValues(['xlsx--11', 'xlsx--12'], $this->defaultStyle));
     }
 
@@ -518,8 +516,7 @@ class WriterWithStyleTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings(true);
 
         $writer->openToFile($resourcePath);
@@ -540,8 +537,7 @@ class WriterWithStyleTest extends TestCase
         $this->createGeneratedFolderIfNeeded($fileName);
         $resourcePath = $this->getGeneratedResourcePath($fileName);
 
-        /** @var \Box\Spout\Writer\XLSX\Writer $writer */
-        $writer = WriterEntityFactory::createWriter(Type::XLSX);
+        $writer = WriterEntityFactory::createXLSXWriter();
         $writer->setShouldUseInlineStrings(true);
         $writer->setDefaultRowStyle($defaultStyle);
 


### PR DESCRIPTION
Removed the `ReaderEntityFactory::createReader(Type)` method and replaced it by 3 methods:
- `ReaderEntityFactory::createCSVReader()`
- `ReaderEntityFactory::createXLSXReader()`
- `ReaderEntityFactory::createODSReader()`

This has the advantage of enabling autocomplete in the IDE, as the return type is no longer the interface but the concrete type. Since readers may expose different options, this is pretty useful.

Similarly, removed the `WriterEntityFactory::createWriter(Type)` method and replaced it by 3 methods:
- `WriterEntityFactory::createCSVWriter()`
- `WriterEntityFactory::createXLSXWriter()`
- `WriterEntityFactory::createODSWriter()`

Since this is a breaking change, I also updated the Upgrade guide.
Finally, the doc is up to date too.