### PR TITLE
Add methods to SheetInterface

### DIFF
--- a/src/Spout/Reader/CSV/Sheet.php
+++ b/src/Spout/Reader/CSV/Sheet.php
@@ -51,4 +51,12 @@ class Sheet implements SheetInterface
     {
         return true;
     }
+
+    /**
+     * @return bool Always TRUE as the only sheet is always visible
+     */
+    public function isVisible()
+    {
+        return true;
+    }
 }

--- a/src/Spout/Reader/SheetInterface.php
+++ b/src/Spout/Reader/SheetInterface.php
@@ -8,9 +8,27 @@ namespace Box\Spout\Reader;
 interface SheetInterface
 {
     /**
-     * Returns an iterator to iterate over the sheet's rows.
-     *
-     * @return IteratorInterface
+     * @return IteratorInterface Iterator to iterate over the sheet's rows.
      */
     public function getRowIterator();
+
+    /**
+     * @return int Index of the sheet
+     */
+    public function getIndex();
+
+    /**
+     * @return string Name of the sheet
+     */
+    public function getName();
+
+    /**
+     * @return bool Whether the sheet was defined as active
+     */
+    public function isActive();
+
+    /**
+     * @return bool Whether the sheet is visible
+     */
+    public function isVisible();
 }


### PR DESCRIPTION
Fixes #626 

The SheetInterface was missing methods common to all Sheets (getIndex, getName, isActive, isVisible).