### PR TITLE
Fix reading of 1904 dates option

### DIFF
--- a/src/Spout/Reader/XLSX/Manager/SheetManager.php
+++ b/src/Spout/Reader/XLSX/Manager/SheetManager.php
@@ -114,7 +114,9 @@ class SheetManager
      */
     protected function processWorkbookPropertiesStartingNode($xmlReader)
     {
-        $shouldUse1904Dates = (bool) $xmlReader->getAttribute(self::XML_ATTRIBUTE_DATE_1904);
+        // Using "filter_var($x, FILTER_VALIDATE_BOOLEAN)" here because the value of the "date1904" attribute
+        // may be the string "false", that is not mapped to the boolean "false" by default...
+        $shouldUse1904Dates = filter_var($xmlReader->getAttribute(self::XML_ATTRIBUTE_DATE_1904), FILTER_VALIDATE_BOOLEAN);
         $this->optionsManager->setOption(Options::SHOULD_USE_1904_DATES, $shouldUse1904Dates);
 
         return XMLProcessor::PROCESSING_CONTINUE;


### PR DESCRIPTION
Fixes #655

Whether the spreadsheet is using 1904 dates or not is controlled by a XML property. Its value can be the string "false" that is not mapped to the boolean "false" but to the boolean "true"... Therefore Spout was previously using the wrong date system when this property was set.