### PR TITLE
Added support for cell formats when writing Excel files

### DIFF
--- a/src/Spout/Common/Entity/Style/Style.php
+++ b/src/Spout/Common/Entity/Style/Style.php
@@ -71,6 +71,12 @@ class Style
     /** @var bool */
     private $hasSetBackgroundColor = false;
 
+    /** @var string Format */
+    private $format = null;
+
+    /** @var bool */
+    private $hasSetFormat = false;
+
     /**
      * @return int|null
      */
@@ -382,5 +388,35 @@ class Style
     public function shouldApplyBackgroundColor()
     {
         return $this->hasSetBackgroundColor;
+    }
+
+    /**
+     * Sets format
+     * @param string $format
+     * @return Style
+     */
+    public function setFormat($format)
+    {
+        $this->hasSetFormat = true;
+        $this->format = $format;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     *
+     * @return bool Whether format should be applied
+     */
+    public function shouldApplyFormat()
+    {
+        return $this->hasSetFormat;
     }
 }

--- a/src/Spout/Common/Entity/Style/Style.php
+++ b/src/Spout/Common/Entity/Style/Style.php
@@ -72,7 +72,7 @@ class Style
     private $hasSetBackgroundColor = false;
 
     /** @var string Format */
-    private $format = null;
+    private $format;
 
     /** @var bool */
     private $hasSetFormat = false;
@@ -412,7 +412,6 @@ class Style
     }
 
     /**
-     *
      * @return bool Whether format should be applied
      */
     public function shouldApplyFormat()

--- a/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
+++ b/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
@@ -147,16 +147,18 @@ class StyleBuilder
 
         return $this;
     }
+
     /**
      *  Sets a format
      *
-     * @api
      * @param string $format Format
      * @return StyleBuilder
+     * @api
      */
     public function setFormat($format)
     {
         $this->style->setFormat($format);
+
         return $this;
     }
 

--- a/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
+++ b/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
@@ -147,6 +147,18 @@ class StyleBuilder
 
         return $this;
     }
+    /**
+     *  Sets a format
+     *
+     * @api
+     * @param string $format Format
+     * @return StyleBuilder
+     */
+    public function setFormat($format)
+    {
+        $this->style->setFormat($format);
+        return $this;
+    }
 
     /**
      * Returns the configured style. The style is cached and can be reused.

--- a/src/Spout/Writer/Common/Manager/Style/StyleMerger.php
+++ b/src/Spout/Writer/Common/Manager/Style/StyleMerger.php
@@ -88,6 +88,9 @@ class StyleMerger
         if (!$style->getBorder() && $baseStyle->shouldApplyBorder()) {
             $styleToUpdate->setBorder($baseStyle->getBorder());
         }
+        if (!$style->getFormat() && $baseStyle->shouldApplyFormat()) {
+            $styleToUpdate->setFormat($baseStyle->getFormat());
+        }
         if (!$style->shouldApplyBackgroundColor() && $baseStyle->shouldApplyBackgroundColor()) {
             $styleToUpdate->setBackgroundColor($baseStyle->getBackgroundColor());
         }

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
@@ -11,6 +11,81 @@ use Box\Spout\Common\Entity\Style\Style;
 class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
 {
     /**
+     * @see https://msdn.microsoft.com/en-us/library/ff529597(v=office.12).aspx
+     * @var array Mapping between built-in format and the associated numFmtId
+     */
+    protected static $builtinNumFormatToIdMapping = [
+
+        'General' => 0,
+        '0' => 1,
+        '0.00' => 2,
+        '#,##0' => 3,
+        '#,##0.00' => 4,
+        '$#,##0,\-$#,##0' => 5,
+        '$#,##0,[Red]\-$#,##0' => 6,
+        '$#,##0.00,\-$#,##0.00' => 7,
+        '$#,##0.00,[Red]\-$#,##0.00' => 8,
+        '0%' => 9,
+        '0.00%' => 10,
+        '0.00E+00' => 11,
+        '# ?/?' => 12,
+        '# ??/??' => 13,
+        'mm-dd-yy' => 14,
+        'd-mmm-yy' => 15,
+        'd-mmm' => 16,
+        'mmm-yy' => 17,
+        'h:mm AM/PM' => 18,
+        'h:mm:ss AM/PM' => 19,
+        'h:mm' => 20,
+        'h:mm:ss' => 21,
+        'm/d/yy h:mm' => 22,
+
+        '#,##0 ,(#,##0)' => 37,
+        '#,##0 ,[Red](#,##0)' => 38,
+        '#,##0.00,(#,##0.00)' => 39,
+        '#,##0.00,[Red](#,##0.00)' => 40,
+
+        '_("$"* #,##0.00_),_("$"* \(#,##0.00\),_("$"* "-"??_),_(@_)' => 44,
+        'mm:ss' => 45,
+        '[h]:mm:ss' => 46,
+        'mm:ss.0' => 47,
+
+        '##0.0E+0' => 48,
+        '@' => 49,
+
+        '[$-404]e/m/d' => 27,
+        'm/d/yy' => 30,
+        't0' => 59,
+        't0.00' => 60,
+        't#,##0' => 61,
+        't#,##0.00' => 62,
+        't0%' => 67,
+        't0.00%' => 68,
+        't# ?/?' => 69,
+        't# ??/??' => 70,
+    ];
+
+
+    /**
+     * @var array
+     */
+    protected $registeredFormats = [];
+
+    /**
+     * @var array [STYLE_ID] => [FORMAT_ID] maps a style to a format declaration
+     */
+    protected $styleIdToFormatsMappingTable = [];
+
+    /**
+     * If the numFmtId is lower than 0xA4 (164 in decimal)
+     * then it's a built-in number format.
+     * Since Excel is the dominant vendor - we play along here
+     *
+     * @var int The fill index counter for custom fills.
+     */
+    protected $formatIndex = 164;
+
+    /**
      * @var array
      */
     protected $registeredFills = [];
@@ -48,9 +123,56 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
     {
         $registeredStyle = parent::registerStyle($style);
         $this->registerFill($registeredStyle);
+        $this->registerFormat($registeredStyle);;
         $this->registerBorder($registeredStyle);
 
         return $registeredStyle;
+    }
+
+    /**
+     * Register a format definition
+     *
+     * @param Style $style
+     */
+    protected function registerFormat(Style $style)
+    {
+        $styleId = $style->getId();
+
+        $format = $style->getFormat();
+        if ($format) {
+            $isFormatRegistered = isset($this->registeredFormats[$format]);
+
+            // We need to track the already registered format definitions
+            if ($isFormatRegistered) {
+                $registeredStyleId = $this->registeredFormats[$format];
+                $registeredFormatId = $this->styleIdToFormatsMappingTable[$registeredStyleId];
+                $this->styleIdToFormatsMappingTable[$styleId] = $registeredFormatId;
+            } else {
+                $this->registeredFormats[$format] = $styleId;
+                if (isset(self::$builtinNumFormatToIdMapping[$format])) {
+                    $id = self::$builtinNumFormatToIdMapping[$format];
+                } else {
+                    $id = $this->formatIndex++;
+                }
+                $this->styleIdToFormatsMappingTable[$styleId] = $id;
+            }
+
+        } else {
+            // The formatId maps a style to a format declaration
+            // When there is no format definition - we default to 0 ( General )
+            $this->styleIdToFormatsMappingTable[$styleId] = 0;
+        }
+    }
+
+    /**
+     * @param int $styleId
+     * @return int|null Format ID associated to the given style ID
+     */
+    public function getFormatIdForStyleId($styleId)
+    {
+        return (isset($this->styleIdToFormatsMappingTable[$styleId])) ?
+            $this->styleIdToFormatsMappingTable[$styleId] :
+            null;
     }
 
     /**
@@ -136,6 +258,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
             null;
     }
 
+
     /**
      * @return array
      */
@@ -151,4 +274,14 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
     {
         return $this->registeredBorders;
     }
+
+
+    /**
+     * @return array
+     */
+    public function getRegisteredFormats()
+    {
+        return $this->registeredFormats;
+    }
+
 }

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
@@ -15,7 +15,6 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
      * @var array Mapping between built-in format and the associated numFmtId
      */
     protected static $builtinNumFormatToIdMapping = [
-
         'General' => 0,
         '0' => 1,
         '0.00' => 2,
@@ -64,7 +63,6 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
         't# ?/?' => 69,
         't# ??/??' => 70,
     ];
-
 
     /**
      * @var array
@@ -123,7 +121,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
     {
         $registeredStyle = parent::registerStyle($style);
         $this->registerFill($registeredStyle);
-        $this->registerFormat($registeredStyle);;
+        $this->registerFormat($registeredStyle);
         $this->registerBorder($registeredStyle);
 
         return $registeredStyle;
@@ -149,6 +147,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
                 $this->styleIdToFormatsMappingTable[$styleId] = $registeredFormatId;
             } else {
                 $this->registeredFormats[$format] = $styleId;
+
                 if (isset(self::$builtinNumFormatToIdMapping[$format])) {
                     $id = self::$builtinNumFormatToIdMapping[$format];
                 } else {
@@ -156,7 +155,6 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
                 }
                 $this->styleIdToFormatsMappingTable[$styleId] = $id;
             }
-
         } else {
             // The formatId maps a style to a format declaration
             // When there is no format definition - we default to 0 ( General )
@@ -258,7 +256,6 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
             null;
     }
 
-
     /**
      * @return array
      */
@@ -275,7 +272,6 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
         return $this->registeredBorders;
     }
 
-
     /**
      * @return array
      */
@@ -283,5 +279,4 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
     {
         return $this->registeredFormats;
     }
-
 }

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
@@ -148,11 +148,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
             } else {
                 $this->registeredFormats[$format] = $styleId;
 
-                if (isset(self::$builtinNumFormatToIdMapping[$format])) {
-                    $id = self::$builtinNumFormatToIdMapping[$format];
-                } else {
-                    $id = $this->formatIndex++;
-                }
+                $id = self::$builtinNumFormatToIdMapping[$format] ?? $this->formatIndex++;
                 $this->styleIdToFormatsMappingTable[$styleId] = $id;
             }
         } else {
@@ -168,9 +164,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
      */
     public function getFormatIdForStyleId($styleId)
     {
-        return (isset($this->styleIdToFormatsMappingTable[$styleId])) ?
-            $this->styleIdToFormatsMappingTable[$styleId] :
-            null;
+        return $this->styleIdToFormatsMappingTable[$styleId] ?? null;
     }
 
     /**

--- a/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
+++ b/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
@@ -41,4 +41,24 @@ class StyleBuilderTest extends TestCase
         $this->assertInstanceOf(Border::class, $baseStyle->getBorder(), 'Base style has a border');
         $this->assertInstanceOf(Border::class, $mergedStyle->getBorder(), 'Merged style has a border');
     }
+
+    /**
+     * @return void
+     */
+    public function testStyleBuilderShouldMergeFormats()
+    {
+        $baseStyle = (new StyleBuilder())
+            ->setFontBold()
+            ->setFormat('0.00')
+            ->build();
+
+        $currentStyle = (new StyleBuilder())->build();
+
+        $styleMerger = new StyleMerger();
+        $mergedStyle = $styleMerger->merge($currentStyle, $baseStyle);
+
+        $this->assertNull($currentStyle->getFormat(), 'Current style has no border');
+        $this->assertEquals('0.00', $baseStyle->getFormat(), 'Base style has a format 0.00');
+        $this->assertEquals('0.00', $mergedStyle->getFormat(), 'Merged style has a format 0.00');
+    }
 }

--- a/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
+++ b/tests/Spout/Writer/XLSX/Manager/Style/StyleRegistryTest.php
@@ -74,4 +74,34 @@ class StyleRegistryTest extends TestCase
         $this->assertEquals(2, $styleRegistry->getBorderIdForStyleId($styleBoderRightBold->getId()), 'Style with border already set should have the same index');
         $this->assertEquals(0, $styleRegistry->getBorderIdForStyleId($styleNoBorder->getId()), 'Style with no border should have index 0');
     }
+
+    /**
+     * @return void
+     */
+    public function testRegisterStyleAlsoRegistersFormats()
+    {
+        $styleRegistry = $this->getStyleRegistry();
+
+        $styleBuiltinFormat = (new StyleBuilder())
+            ->setFontBold()
+            ->setFormat('0.00')//Builtin format
+            ->build();
+
+        $styleUserFormat = (new StyleBuilder())
+            ->setFontBold()
+            ->setFormat('0.000')
+            ->build();
+        $styleNoFormat = (new StyleBuilder())->setFontItalic()->build();
+
+        $styleRegistry->registerStyle($styleBuiltinFormat);
+        $styleRegistry->registerStyle($styleUserFormat);
+        $styleRegistry->registerStyle($styleNoFormat);
+
+        $this->assertCount(2, $styleRegistry->getRegisteredFormats(), 'There should be 2 registered formats');
+
+        $this->assertEquals(2, $styleRegistry->getFormatIdForStyleId($styleBuiltinFormat->getId()), 'First style with builtin format set should have index 2 (0 is for the default style)');
+        $this->assertEquals(164, $styleRegistry->getFormatIdForStyleId($styleUserFormat->getId()), 'Second style with user format set should have index 164 (0 is for the default style)');
+
+        $this->assertEquals(0, $styleRegistry->getFormatIdForStyleId($styleNoFormat->getId()), 'Style with no format should have index 0');
+    }
 }

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -213,6 +213,47 @@ class WriterWithStyleTest extends TestCase
     /**
      * @return void
      */
+    public function testAddRowWithNumFmtStyles()
+    {
+        $fileName = 'test_add_row_with_numfmt.xlsx';
+        $style = (new StyleBuilder())
+            ->setFontBold()
+            ->setFormat('0.00')//Builtin format
+            ->build();
+        $style2 = (new StyleBuilder())
+            ->setFontBold()
+            ->setFormat('0.000')
+            ->build();
+
+
+        $dataRows = [
+            $this->createStyledRowFromValues([1.123456789], $style),
+            $this->createStyledRowFromValues([12.1], $style2),
+        ];
+
+        $this->writeToXLSXFile($dataRows, $fileName);
+
+
+        $formatsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'numFmts');
+        $this->assertEquals(
+            1,
+            $formatsDomElement->getAttribute('count'),
+            'There should be 2 formats, including the 1 default ones'
+        );
+
+
+        $cellXfsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'cellXfs');
+
+        foreach ([2, 164] as $index => $expected) {
+            $xfElement = $cellXfsDomElement->getElementsByTagName('xf')->item($index + 1);
+            $this->assertEquals($expected, $xfElement->getAttribute('numFmtId'));
+
+        }
+    }
+
+    /**
+     * @return void
+     */
     public function testAddRowShouldAddWrapTextAlignmentInfoInStylesXmlFileIfSpecified()
     {
         $fileName = 'test_add_row_should_add_wrap_text_alignment.xlsx';

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -225,14 +225,12 @@ class WriterWithStyleTest extends TestCase
             ->setFormat('0.000')
             ->build();
 
-
         $dataRows = [
             $this->createStyledRowFromValues([1.123456789], $style),
             $this->createStyledRowFromValues([12.1], $style2),
         ];
 
         $this->writeToXLSXFile($dataRows, $fileName);
-
 
         $formatsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'numFmts');
         $this->assertEquals(
@@ -241,13 +239,11 @@ class WriterWithStyleTest extends TestCase
             'There should be 2 formats, including the 1 default ones'
         );
 
-
         $cellXfsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'cellXfs');
 
         foreach ([2, 164] as $index => $expected) {
             $xfElement = $cellXfsDomElement->getElementsByTagName('xf')->item($index + 1);
             $this->assertEquals($expected, $xfElement->getAttribute('numFmtId'));
-
         }
     }
 

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -236,7 +236,7 @@ class WriterWithStyleTest extends TestCase
         $this->assertEquals(
             1,
             $formatsDomElement->getAttribute('count'),
-            'There should be 2 formats, including the 1 default ones'
+            'There should be 2 formats, including the default one'
         );
 
         $cellXfsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'cellXfs');


### PR DESCRIPTION
Added support for cell formats when writing Excel files

Example:

```php
$style = (new StyleBuilder())
            ->setFontBold()
            ->setFormat('0.00')//Builtin format
            ->build();

$style2 = (new StyleBuilder())
            ->setFontBold()
            ->setFormat('0.000')
            ->build();
```