### PR TITLE
[PHP 7.4] Updated way to disable the fgetcsv/fputcsv escape character

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -90,7 +90,7 @@ class GlobalFunctionsHelper
         // To fix that, simply disable the escape character.
         // @see https://bugs.php.net/bug.php?id=43225
         // @see http://tools.ietf.org/html/rfc4180
-        $escapeCharacter = "\0";
+        $escapeCharacter = PHP_VERSION_ID >= 70400 ? '' : "\0";
 
         return fgetcsv($handle, $length, $delimiter, $enclosure, $escapeCharacter);
     }
@@ -111,7 +111,7 @@ class GlobalFunctionsHelper
         // To fix that, simply disable the escape character.
         // @see https://bugs.php.net/bug.php?id=43225
         // @see http://tools.ietf.org/html/rfc4180
-        $escapeCharacter = "\0";
+        $escapeCharacter = PHP_VERSION_ID >= 70400 ? '' : "\0";
 
         return fputcsv($handle, $fields, $delimiter, $enclosure, $escapeCharacter);
     }


### PR DESCRIPTION
Fixes #658

From PHP 7.4, the recommended way to disable the escape character for fgetcsv() and fputcsv() is an empty string, instead of "\0".
Discussed here: https://github.com/php/php-src/pull/3515