### PR TITLE
Switch documentation site to HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ All contributions are welcome to this project.
 
 Before a contribution can be merged into this project, please fill out the Contributor License Agreement (CLA) located at:
 
-http://opensource.box.com/cla
+https://opensource.box.com/cla
 
 To learn more about CLAs and why they are important to open source projects, please see the [Wikipedia entry](http://en.wikipedia.org/wiki/Contributor_License_Agreement).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spout
 
 [![Latest Stable Version](https://poser.pugx.org/box/spout/v/stable)](https://packagist.org/packages/box/spout)
-[![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
+[![Project Status](https://opensource.box.com/badges/active.svg)](https://opensource.box.com/badges)
 [![Build Status](https://travis-ci.org/box/spout.svg?branch=master)](https://travis-ci.org/box/spout)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/box/spout/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/box/spout/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/box/spout/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/box/spout/?branch=master)
@@ -15,7 +15,7 @@ Join the community and come discuss about Spout: [![Gitter](https://badges.gitte
 
 ## Documentation
 
-Full documentation can be found at [http://opensource.box.com/spout/](http://opensource.box.com/spout/).
+Full documentation can be found at [https://opensource.box.com/spout/](https://opensource.box.com/spout/).
 
 
 ## Requirements

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ title: Spout
 email: oss@box.com
 description: "An open source PHP library to read and write spreadsheet files (XLSX, ODS and CSV), in a fast and scalable way."
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://opensource.box.com" # the base hostname & protocol for your site
+url: "https://opensource.box.com" # the base hostname & protocol for your site
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Fixes #689

Accessing the website through HTTP may be blocked in some regions of the world.
Using HTTPS should help with this problem and is the good thing to do anyway.