### PR TITLE
[Docs] Force using current protocol scheme for resources and links

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -6,7 +6,7 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.github.url }}">
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site_url }}">
   {% if site.algolia.enabled %}
   <link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
   {% endif %}

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header">
 
   <div class="wrapper">
-    <a class="site-title" href="{{ site.github.url }}/">{{ site.title }}</a>
+    <a class="site-title" href="{{ site_url }}/">{{ site.title }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">
@@ -12,10 +12,10 @@
         </svg>
       </a>
       <div class="trigger">
-        <a class="page-link" href="{{ site.github.url }}/getting-started/">Getting Started</a>
-        <a class="page-link" href="{{ site.github.url }}/docs/">Documentation</a>
-        <a class="page-link" href="{{ site.github.url }}/guides/">Guides</a>
-        <a class="page-link" href="{{ site.github.url }}/faq/">FAQ</a>
+        <a class="page-link" href="{{ site_url }}/getting-started/">Getting Started</a>
+        <a class="page-link" href="{{ site_url }}/docs/">Documentation</a>
+        <a class="page-link" href="{{ site_url }}/guides/">Guides</a>
+        <a class="page-link" href="{{ site_url }}/faq/">FAQ</a>
         <a class="page-link" href="{{ site.github.repository_url }}">
             <span class="icon icon--github">{% include icon-github.svg %}</span>
             <span class="username">GitHub</span>

--- a/docs/_includes/section-why-use-spout.html
+++ b/docs/_includes/section-why-use-spout.html
@@ -13,7 +13,7 @@
         <li class="feature-check">{{ site.spout_html }}'s API is {{emS}}developer-friendly{{emE}}.</li>
     </ul><br>
     <div class="btn-wrapper">
-        <a href="{{ site.github.url }}/getting-started/" class="page-link"><button class="btn">Get started</button></a>
+        <a href="{{ site_url }}/getting-started/" class="page-link"><button class="btn">Get started</button></a>
     </div>
 {% endcapture %}
 

--- a/docs/_includes/section.html
+++ b/docs/_includes/section.html
@@ -9,7 +9,7 @@
       {% assign sectionIconsAsArray = sectionIcons | split:'~~' %}
       <div class="icons">
       {% for icon in sectionIconsAsArray %}
-        <img src="{{ site.github.url }}/images/{{ icon }}"/>
+        <img src="{{ site_url }}/images/{{ icon }}"/>
       {% endfor %}
       </div>
     {% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html>
+  {% assign protocol_scheme = page.url | absolute_url | truncate: 5, "" %}
+  {%- capture site_url -%}
+    {%- if protocol_scheme == "https" -%}
+      <!-- This is a hack to force using HTTPS... -->
+      <!-- The URL of the docs should be changed in the repo settings instead -->
+      {{ site.github.url | replace: "http", "https" }}
+    {%- else -%}
+      {{ site.github.url }}
+    {%- endif -%}
+  {%- endcapture -%}
 
   {% include head.html %}
 

--- a/docs/_pages/getting-started.md
+++ b/docs/_pages/getting-started.md
@@ -134,4 +134,4 @@ For XLSX and ODS files, the number of rows per sheet is limited to *1,048,576*. 
 
 ## Advanced usage
 
-You can do a lot more with {{ site.spout_html }}! Check out the [full documentation]({{ site.github.url }}/docs/) to learn about all the features.
+You can do a lot more with {{ site.spout_html }}! Check out the [full documentation]({{ site_url }}/docs/) to learn about all the features.

--- a/docs/_pages/guides.md
+++ b/docs/_pages/guides.md
@@ -5,14 +5,14 @@ permalink: /guides/
 ---
 
 These guides focus on common and more advanced usages of {{ site.spout_html }}.<br>
-If you are just starting with {{ site.spout_html }}, check out the [Getting Started page]({{ site.github.url }}/getting-started/) and the [Documentation]({{ site.github.url }}/docs/) first.
+If you are just starting with {{ site.spout_html }}, check out the [Getting Started page]({{ site_url }}/getting-started/) and the [Documentation]({{ site_url }}/docs/) first.
 
 {% assign pages=site.pages | sort: 'path' %}
 <ul>
 {% for page in pages %}
   {% if page.title and page.category contains 'guide' %}
   <li>
-    <a class="page-link" href="{{ page.url | prepend: site.github.url }}">{{ page.title }}</a>
+    <a class="page-link" href="{{ page.url | prepend: site_url }}">{{ page.title }}</a>
   </li>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fixes #689

If the docs is accessed with https, change all links to be https as well.