### PR TITLE
disable no_superfluous_phpdoc_tags

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,7 @@ $config = PhpCsFixer\Config::create()
         'no_null_property_initialization' => true,
         'no_short_echo_tag' => true,
         'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => false,
         'no_unneeded_control_parentheses' => ['statements' => ['break', 'clone', 'continue', 'echo_print', 'switch_case', 'yield']],
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,


### PR DESCRIPTION
* Disables "no_superfluous_phpdoc_tags"
* See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2979

* Other options: Enable it and fix all occurences
* Pin Cs Fixer to a specific version, where this option was not merged in upstream