### PR TITLE
add PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 
 language: php
@@ -13,6 +13,9 @@ matrix:
       env: WITH_PHPUNIT=true
     - php: 7.3
       env: WITH_PHPUNIT=true
+    - php: 7.4
+      env: WITH_PHPUNIT=true
+
 
 cache:
   directories:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,10 @@
         defaultTestSuite="unit-tests"
         verbose="false">
 
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
     <testsuites>
 
         <testsuite name="unit-tests">

--- a/src/Spout/Common/Helper/FileSystemHelper.php
+++ b/src/Spout/Common/Helper/FileSystemHelper.php
@@ -17,7 +17,7 @@ class FileSystemHelper implements FileSystemHelperInterface
     /**
      * @param string $baseFolderPath The path of the base folder where all the I/O can occur
      */
-    public function __construct($baseFolderPath)
+    public function __construct(string $baseFolderPath)
     {
         $this->baseFolderRealPath = \realpath($baseFolderPath);
     }
@@ -117,12 +117,16 @@ class FileSystemHelper implements FileSystemHelperInterface
      * should occur is not inside the base folder.
      *
      * @param string $operationFolderPath The path of the folder where the I/O operation should occur
-     * @throws \Box\Spout\Common\Exception\IOException If the folder where the I/O operation should occur is not inside the base folder
+     * @throws \Box\Spout\Common\Exception\IOException If the folder where the I/O operation should occur
+     * is not inside the base folder or the base folder does not exist
      * @return void
      */
-    protected function throwIfOperationNotInBaseFolder($operationFolderPath)
+    protected function throwIfOperationNotInBaseFolder(string $operationFolderPath)
     {
         $operationFolderRealPath = \realpath($operationFolderPath);
+        if (!$this->baseFolderRealPath) {
+            throw new IOException("The base folder path is invalid: {$this->baseFolderRealPath}");
+        }
         $isInBaseFolder = (\strpos($operationFolderRealPath, $this->baseFolderRealPath) === 0);
         if (!$isInBaseFolder) {
             throw new IOException("Cannot perform I/O operation outside of the base folder: {$this->baseFolderRealPath}");


### PR DESCRIPTION
* Add PHP 7.4 to the test grid
* Fix "PHP Deprecated:  strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /home/travis/build/madflow/spout/src/Spout/Common/Helper/FileSystemHelper.php on line 126"
* `FileSystemHelper::baseFolderRealPath` is set with `realpath` - which can also be `false`.