### PR TITLE
Allow accent in Filename

### DIFF
--- a/src/Spout/Writer/WriterAbstract.php
+++ b/src/Spout/Writer/WriterAbstract.php
@@ -125,7 +125,7 @@ abstract class WriterAbstract implements WriterInterface
 
         // Set headers
         $this->globalFunctionsHelper->header('Content-Type: ' . static::$headerContentType);
-        $this->globalFunctionsHelper->header('Content-Disposition: attachment; filename="' . $this->outputFilePath . '"');
+        $this->globalFunctionsHelper->header($this->getContentDispositionHeader());
 
         /*
          * When forcing the download of a file over SSL,IE8 and lower browsers fail
@@ -141,6 +141,16 @@ abstract class WriterAbstract implements WriterInterface
         $this->isWriterOpened = true;
 
         return $this;
+    }
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+     * @link https://tools.ietf.org/html/rfc5987
+     * @link https://tools.ietf.org/html/rfc2231#section-4
+     */
+    protected function getContentDispositionHeader(): string
+    {
+        return 'Content-Disposition: attachment; filename="' . iconv('UTF-8', 'ASCII//IGNORE', $this->outputFilePath) . '"; filename*=utf-8\'\'' . rawurlencode($this->outputFilePath);
     }
 
     /**

--- a/src/Spout/Writer/WriterAbstract.php
+++ b/src/Spout/Writer/WriterAbstract.php
@@ -144,11 +144,11 @@ abstract class WriterAbstract implements WriterInterface
     }
 
     /**
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
-     * @link https://tools.ietf.org/html/rfc5987
-     * @link https://tools.ietf.org/html/rfc2231#section-4
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+     * @see https://tools.ietf.org/html/rfc5987
+     * @see https://tools.ietf.org/html/rfc2231#section-4
      */
-    protected function getContentDispositionHeader(): string
+    protected function getContentDispositionHeader() : string
     {
         return 'Content-Disposition: attachment; filename="' . iconv('UTF-8', 'ASCII//IGNORE', $this->outputFilePath) . '"; filename*=utf-8\'\'' . rawurlencode($this->outputFilePath);
     }


### PR DESCRIPTION
Protected function allow overwrite without full copy paste
Even if you have to rewrite the factory method anyway ...

first filename will be a fallback in ASCII for browser not supporting second filename with asterisk