### PR TITLE
Added support for mergeCells, cell height, shrink to fit

### DIFF
--- a/src/Spout/Common/Entity/Row.php
+++ b/src/Spout/Common/Entity/Row.php
@@ -19,6 +19,12 @@ class Row
     protected $style;
 
     /**
+     * Row height (default is 15)
+     * @var string
+     */
+    protected $height = "15";
+
+    /**
      * Row constructor.
      * @param Cell[] $cells
      * @param Style|null $style
@@ -125,5 +131,25 @@ class Row
         return \array_map(function (Cell $cell) {
             return $cell->getValue();
         }, $this->cells);
+    }
+
+    /**
+     * Set row height
+     * @param String $height
+     * @return Row
+     */
+    public function setHeight($height)
+    {
+        $this->height = $height;
+        return $this;
+    }
+
+    /**
+     * Returns row height
+     * @return String
+     */
+    public function getHeight()
+    {
+        return $this->height;
     }
 }

--- a/src/Spout/Common/Entity/Style/Style.php
+++ b/src/Spout/Common/Entity/Style/Style.php
@@ -66,6 +66,9 @@ class Style
     /** @var bool Whether the wrap text property was set */
     private $hasSetWrapText = false;
 
+    private $shrinkToFit = false;
+    private $shouldShrinkToFit = false;
+
     /** @var Border */
     private $border;
 
@@ -462,5 +465,25 @@ class Style
     public function shouldApplyFormat()
     {
         return $this->hasSetFormat;
+    }
+
+    /**
+     * Sets should shrink to fit
+     * @param bool $shrinkToFit
+     * @return Style
+     */
+    public function setShouldShrinkToFit($shrinkToFit = true)
+    {
+        $this->shrinkToFit = $shrinkToFit;
+        $this->shouldShrinkToFit = $shrinkToFit;
+        return $this;
+    }
+
+     /**
+     * @return bool Whether format should be applied
+     */
+    public function shouldShrinkToFit()
+    {
+        return $this->shouldShrinkToFit;
     }
 }

--- a/src/Spout/Common/Manager/OptionsManagerAbstract.php
+++ b/src/Spout/Common/Manager/OptionsManagerAbstract.php
@@ -52,6 +52,21 @@ abstract class OptionsManagerAbstract implements OptionsManagerInterface
     }
 
     /**
+     * Add an option to the internal list of options
+     * Used only for mergeCells() for now
+     * @return void
+     */
+    public function addOption($optionName, $optionValue)
+    {
+        if (\in_array($optionName, $this->supportedOptions)) {
+            if (!isset($this->options[$optionName])) {
+                $this->options[$optionName] = [];
+            }
+            $this->options[$optionName][] = $optionValue;
+        }
+    }
+
+    /**
      * @param string $optionName
      * @return mixed|null The set option or NULL if no option with given name found
      */

--- a/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
+++ b/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
@@ -184,6 +184,17 @@ class StyleBuilder
     }
 
     /**
+     * Set should shrink to fit
+     * @param boolean $shrinkToFit
+     * @return void
+     */
+    public function setShouldShrinkToFit($shrinkToFit = true)
+    {
+        $this->style->setShouldShrinkToFit($shrinkToFit);
+        return $this;
+    }
+
+    /**
      * Returns the configured style. The style is cached and can be reused.
      *
      * @return Style

--- a/src/Spout/Writer/Common/Entity/Options.php
+++ b/src/Spout/Writer/Common/Entity/Options.php
@@ -20,4 +20,10 @@ abstract class Options
 
     // XLSX specific options
     const SHOULD_USE_INLINE_STRINGS = 'shouldUseInlineStrings';
+
+    // XLSX column widths
+    const COLUMN_WIDTHS = 'columnWidths';
+
+    // XLSX merge cells
+    const MERGE_CELLS = 'mergeCells';
 }

--- a/src/Spout/Writer/Common/Entity/Sheet.php
+++ b/src/Spout/Writer/Common/Entity/Sheet.php
@@ -27,6 +27,9 @@ class Sheet
     /** @var SheetManager Sheet manager */
     private $sheetManager;
 
+    /** @var bool Sheet is started */
+    private $isSheetStarted = false;
+
     /**
      * @param int $sheetIndex Index of the sheet, based on order in the workbook (zero-based)
      * @param string $associatedWorkbookId ID of the sheet's associated workbook
@@ -105,6 +108,25 @@ class Sheet
     public function setIsVisible($isVisible)
     {
         $this->isVisible = $isVisible;
+
+        return $this;
+    }
+
+    /**
+     * @return bool isSheetStarted Sheet was started
+     */
+    public function isSheetStarted()
+    {
+        return $this->isSheetStarted;
+    }
+
+    /**
+     * @param bool $isSheetStarted Set if sheet was started
+     * @return Sheet
+     */
+    public function setIsSheetStarted($isSheetStarted)
+    {
+        $this->isSheetStarted = $isSheetStarted;
 
         return $this;
     }

--- a/src/Spout/Writer/WriterMultiSheetsAbstract.php
+++ b/src/Spout/Writer/WriterMultiSheetsAbstract.php
@@ -62,6 +62,29 @@ abstract class WriterMultiSheetsAbstract extends WriterAbstract
     }
 
     /**
+     * Set columns widths as list. If value is null will set column with default width (8.43)
+     * @param array $columnWidths
+     * @return WriterMultiSheetsAbstract
+     */
+    public function setColumnWidths(array $columnWidths)
+    {
+        $this->optionsManager->setOption(Options::COLUMN_WIDTHS, $columnWidths);
+        return $this;
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param array $range
+     * @return void
+     */
+    public function mergeCells(array $range1, array $range2)
+    {
+        $this->optionsManager->addOption(Options::MERGE_CELLS, [$range1, $range2]);
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function openWriter()

--- a/src/Spout/Writer/XLSX/Manager/OptionsManager.php
+++ b/src/Spout/Writer/XLSX/Manager/OptionsManager.php
@@ -39,6 +39,8 @@ class OptionsManager extends OptionsManagerAbstract
             Options::DEFAULT_ROW_STYLE,
             Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY,
             Options::SHOULD_USE_INLINE_STRINGS,
+            Options::COLUMN_WIDTHS,
+            Options::MERGE_CELLS,
         ];
     }
 
@@ -56,5 +58,7 @@ class OptionsManager extends OptionsManagerAbstract
         $this->setOption(Options::DEFAULT_ROW_STYLE, $defaultRowStyle);
         $this->setOption(Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY, true);
         $this->setOption(Options::SHOULD_USE_INLINE_STRINGS, true);
+        $this->setOption(Options::COLUMN_WIDTHS, []);
+        $this->setOption(Options::MERGE_CELLS, []);
     }
 }

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleManager.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleManager.php
@@ -258,6 +258,10 @@ EOD;
                 if ($style->shouldWrapText()) {
                     $content .= ' wrapText="1"';
                 }
+                if ($style->shouldShrinkToFit()) {
+                    $content .= ' shrinkToFit="true"';
+                }
+
                 $content .= '/>';
                 $content .= '</xf>';
             } else {


### PR DESCRIPTION
Added support for
    mergeCells:
        // mergeCells (B2:G2), you may use CellHelper::getColumnLettersFromColumnIndex() to convert from "B2" to "[1,2]"
	    $writer->mergeCells([1,2], [6, 2]);

    cell height:
        $row->setHeight(30);

    shouldShrinkToFit:
        $style->setShouldShrinkToFit();

These changes are implemented for XLSX as that's what I need and test spout on.