### PR TITLE
Shorter (relevant) diff by php-cs-fixer for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
 script:
   - |
     if [[ "$WITH_CS" == "true" ]]; then
-        vendor/bin/php-cs-fixer fix --config=.php_cs.dist --verbose --diff --dry-run
+        vendor/bin/php-cs-fixer fix --config=.php_cs.dist --verbose --diff --dry-run --diff-format=udiff
     fi
   - |
     if [[ "$WITH_PHPUNIT" == "true" ]]; then


### PR DESCRIPTION
Hello,

This PR makes the report of php-cs-fixer way shorter by printing only the diff parts. The current diff format prints the diff parts and the rest of the file, which makes it pretty hard to browse.

Travis failure will be unrelated (see #747)

Update: you can compare [this report (with shorter diff)](https://travis-ci.org/github/box/spout/jobs/692493395) and [this one (with current diff format)](https://travis-ci.org/github/box/spout/jobs/692494711) to see the difference :)