### PR TITLE
Add support for writing date cells

### DIFF
--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -214,7 +214,7 @@ class WorksheetManager implements WorksheetManagerInterface
                 // workaround for missing DateInterval::format('c'), see https://stackoverflow.com/a/61088115/53538
                 static $f = ['M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'];
                 static $r = ['M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'];
-                $value = rtrim(str_replace($f, $r, $value->format('P%yY%mM%dDT%hH%iM%sS')), 'PT') ?: $default;
+                $value = rtrim(str_replace($f, $r, $value->format('P%yY%mM%dDT%hH%iM%sS')), 'PT') ?: 'PT0S';
                 $data .= ' office:value-type="time" office:time-value="' . $value . '">';
                 $data .= '<text:p>' . $value . '</text:p>';
             } else {

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -207,10 +207,10 @@ class WorksheetManager implements WorksheetManagerInterface
         } elseif ($cell->isDate()) {
             $value = $cell->getValue();
             if ($value instanceof \DateTime) {
-                $datevalue = substr($value->setTimezone(new \DateTimeZone("UTC"))->format(\DateTimeInterface::W3C),0,-6);
+                $datevalue = substr($value->setTimezone(new \DateTimeZone('UTC'))->format(\DateTimeInterface::W3C), 0, -6);
                 $data .= ' office:value-type="date" calcext:value-type="date" office:date-value="' . $datevalue . 'Z">';
                 $data .= '<text:p>' . $datevalue . 'Z</text:p>';
-            } else if ($value instanceof \DateInterval) {
+            } elseif ($value instanceof \DateInterval) {
                 // workaround for missing DateInterval::format('c'), see https://stackoverflow.com/a/61088115/53538
                 static $f = ['M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'];
                 static $r = ['M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'];

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -207,8 +207,9 @@ class WorksheetManager implements WorksheetManagerInterface
         } elseif ($cell->isDate()) {
             $value = $cell->getValue();
             if ($value instanceof \DateTime) {
-                $data .= ' office:value-type="date" calcext:value-type="date" office:date-value="' . $value->format(\DateTimeInterface::W3C) . '">';
-                $data .= '<text:p>' . $value->format(\DateTimeInterface::W3C) . '</text:p>';
+                $datevalue = substr($value->setTimezone(new \DateTimeZone("UTC"))->format(\DateTimeInterface::W3C),0,-6);
+                $data .= ' office:value-type="date" calcext:value-type="date" office:date-value="' . $datevalue . '">';
+                $data .= '<text:p>' . $datevalue . '</text:p>';
             } else if ($value instanceof \DateInterval) {
                 // workaround for missing DateInterval::format('c'), see https://stackoverflow.com/a/61088115/53538
                 static $f = ['M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'];

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -208,8 +208,8 @@ class WorksheetManager implements WorksheetManagerInterface
             $value = $cell->getValue();
             if ($value instanceof \DateTime) {
                 $datevalue = substr($value->setTimezone(new \DateTimeZone("UTC"))->format(\DateTimeInterface::W3C),0,-6);
-                $data .= ' office:value-type="date" calcext:value-type="date" office:date-value="' . $datevalue . '">';
-                $data .= '<text:p>' . $datevalue . '</text:p>';
+                $data .= ' office:value-type="date" calcext:value-type="date" office:date-value="' . $datevalue . 'Z">';
+                $data .= '<text:p>' . $datevalue . 'Z</text:p>';
             } else if ($value instanceof \DateInterval) {
                 // workaround for missing DateInterval::format('c'), see https://stackoverflow.com/a/61088115/53538
                 static $f = ['M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'];


### PR DESCRIPTION
The ODS writer is missing support for cells of type `DateTime` to use the ODS cell type `office:date-value`. This code also puts in the `calcext` types... because it doesn't hurt, I guess?