### PR TITLE
Fix private methods cannot be final as they are never overridden by other classes

### DIFF
--- a/src/Spout/Common/Singleton.php
+++ b/src/Spout/Common/Singleton.php
@@ -36,6 +36,6 @@ trait Singleton
      */
     protected function init() {}
 
-    final private function __wakeup() {}
-    final private function __clone() {}
+    public function __wakeup() {}
+    public function __clone() {}
 }


### PR DESCRIPTION
This PR fix the `Private methods cannot be final as they are never overridden by other classes` warning and the `During class fetch: Uncaught The magic method Box\Spout\Common\Singleton::__wakeup() must have public visibility` on php 8.0.