### PR TITLE
Fix applyNumberFormat default value for XLSX

### DIFF
--- a/src/Spout/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Spout/Reader/XLSX/Manager/StyleManager.php
@@ -175,7 +175,7 @@ class StyleManager
                 $normalizedNumFmtId = ($numFmtId !== null) ? (int) $numFmtId : null;
 
                 $applyNumberFormat = $xmlReader->getAttribute(self::XML_ATTRIBUTE_APPLY_NUMBER_FORMAT);
-                $normalizedApplyNumberFormat = ($applyNumberFormat !== null) ? (bool) $applyNumberFormat : null;
+                $normalizedApplyNumberFormat = ($applyNumberFormat !== null) ? (bool) $applyNumberFormat : false;
 
                 $this->stylesAttributes[] = [
                     self::XML_ATTRIBUTE_NUM_FMT_ID          => $normalizedNumFmtId,


### PR DESCRIPTION
When extract style attribute, a missing "applyNumberFormat" attribute would lead to a bool value being filled with `null`. This value would then be used for comparison (`if ($applyNumberFormat === false)`). This does not take into account the nullable aspect of the value.
There is no reason to keep this value as nullable. If the attribute does not exist, then we should default to "false" (as in "Do not try to apply number format here").

Fixes #771 