### PR TITLE
XLSX Date Writer

### DIFF
--- a/src/Spout/Common/Helper/CellTypeHelper.php
+++ b/src/Spout/Common/Helper/CellTypeHelper.php
@@ -61,7 +61,7 @@ class CellTypeHelper
     public static function isDateTimeOrDateInterval($value)
     {
         return (
-            $value instanceof \DateTime ||
+            $value instanceof \DateTimeInterface ||
             $value instanceof \DateInterval
         );
     }

--- a/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
@@ -237,6 +237,8 @@ EOD;
 
         if ($cell->isString()) {
             $cellXML .= $this->getCellXMLFragmentForNonEmptyString($cell->getValue());
+        } elseif ($cell->isDate()) {
+            $cellXML .= ' t="d"><v>' . $cell->getValue()->format(\DateTimeInterface::ATOM) . '</v></c>';
         } elseif ($cell->isBoolean()) {
             $cellXML .= ' t="b"><v>' . (int) ($cell->getValue()) . '</v></c>';
         } elseif ($cell->isNumeric()) {

--- a/tests/Spout/Common/Helper/CellTypeHelperTest.php
+++ b/tests/Spout/Common/Helper/CellTypeHelperTest.php
@@ -83,4 +83,25 @@ class CellTypeHelperTest extends TestCase
         $this->assertFalse(CellTypeHelper::isBoolean(new \stdClass()));
         $this->assertFalse(CellTypeHelper::isBoolean(null));
     }
+
+    /**
+     * @return array
+     */
+    public function testIsDateOrInterval()
+    {
+        $this->assertTrue(CellTypeHelper::isDateTimeOrDateInterval(new \DateTime()));
+        $this->assertTrue(CellTypeHelper::isDateTimeOrDateInterval(new \DateInterval('P1D')));
+
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(true));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(false));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(0));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(1));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval('0'));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval('1'));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval('true'));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval('false'));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval([true]));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(new \stdClass()));
+        $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(null));
+    }
 }

--- a/tests/Spout/Common/Helper/CellTypeHelperTest.php
+++ b/tests/Spout/Common/Helper/CellTypeHelperTest.php
@@ -90,6 +90,7 @@ class CellTypeHelperTest extends TestCase
     public function testIsDateOrInterval()
     {
         $this->assertTrue(CellTypeHelper::isDateTimeOrDateInterval(new \DateTime()));
+        $this->assertTrue(CellTypeHelper::isDateTimeOrDateInterval(new \DateTimeImmutable()));
         $this->assertTrue(CellTypeHelper::isDateTimeOrDateInterval(new \DateInterval('P1D')));
 
         $this->assertFalse(CellTypeHelper::isDateTimeOrDateInterval(true));

--- a/tests/Spout/Writer/XLSX/WriterTest.php
+++ b/tests/Spout/Writer/XLSX/WriterTest.php
@@ -365,7 +365,7 @@ class WriterTest extends TestCase
     {
         $fileName = 'test_add_row_should_support_multiple_types_of_data.xlsx';
         $dataRows = $this->createRowsFromValues([
-            ['xlsx--11', true, '', 0, 10.2, null],
+            ['xlsx--11', true, '', 0, 10.2, null, new \DateTime('2021-01-01'), new \DateTimeImmutable('2021-02-02')],
         ]);
 
         $this->writeToXLSXFile($dataRows, $fileName, $shouldUseInlineStrings = false);


### PR DESCRIPTION
Adds support for writing instances of `DateTimeInterface` (ie. `DateTime` and `DateTimeImmutable`) with the XLSX writer.

Previous issues such as #781 and #797 have been closed with regards this issue, but I believe #781 is actually valid. From my research (disclaimer: I'm new to this XML format...) it seems the numeric date format for "serial dates" referenced in the closing comment of #781 are those originally supported by openxml, for example...

```xml
<c s="14">
  <v>44401</v>
</c>
```

However, ISO/IEC 29500-1:2016 adds support for ISO dates using the type `d`.

https://www.iso.org/standard/71691.html

![image](https://user-images.githubusercontent.com/447579/119399806-3d71ff80-bcd1-11eb-84ef-929139a4d709.png)

```xml
<c t="d" s="14">
  <v>2021-02-03T12:34:45</v>
</c>
```

Thoughts? If this is valid I'm happy to re-work this PR as needed, cheers.