### PR TITLE
[DX] more helpful exception message in case of invalid value

### DIFF
--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -243,7 +243,7 @@ class WorksheetManager implements WorksheetManagerInterface
         } elseif ($cell->isEmpty()) {
             $data .= '/>';
         } else {
-            $value = $cell->getValue();
+            $value = $cell->getValueEvenIfError();
 
             throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
         }

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -243,7 +243,9 @@ class WorksheetManager implements WorksheetManagerInterface
         } elseif ($cell->isEmpty()) {
             $data .= '/>';
         } else {
-            throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . \gettype($cell->getValue()));
+            $value = $cell->getValue();
+
+            throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
         }
 
         return $data;

--- a/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
@@ -253,7 +253,7 @@ EOD;
                 $cellXML = '';
             }
         } else {
-            $value = $cell->getValue();
+            $value = $cell->getValueEvenIfError();
 
             throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
         }

--- a/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/XLSX/Manager/WorksheetManager.php
@@ -253,7 +253,9 @@ EOD;
                 $cellXML = '';
             }
         } else {
-            throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . \gettype($cell->getValue()));
+            $value = $cell->getValue();
+
+            throw new InvalidArgumentException('Trying to add a value with an unsupported type: ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
         }
 
         return $cellXML;


### PR DESCRIPTION
It is should provide a more helpful message for developer in exception, when in cell value provided an object.

**Example**:

Exception:
```
Uncaught PHP Exception Box\\Spout\\Common\\Exception\\InvalidArgumentException: \"Trying to add a value with an unsupported type: NULL\" at /project/vendor/box/spout/src/Spout/Writer/XLSX/Manager/WorksheetManager.php line 256
```

I may assume, that in my code somewhere used `null` and passed to `spout`, but the real reason was - object was provided for cell value, and this lead to described above exception.


This PR will improve an error message and provide a better DX.