### PR TITLE
Add dedicated RowIteratorInterface and SheetIteratorInterface

### DIFF
--- a/src/Spout/Reader/CSV/RowIterator.php
+++ b/src/Spout/Reader/CSV/RowIterator.php
@@ -8,13 +8,13 @@ use Box\Spout\Common\Helper\GlobalFunctionsHelper;
 use Box\Spout\Common\Manager\OptionsManagerInterface;
 use Box\Spout\Reader\Common\Entity\Options;
 use Box\Spout\Reader\CSV\Creator\InternalEntityFactory;
-use Box\Spout\Reader\IteratorInterface;
+use Box\Spout\Reader\RowIteratorInterface;
 
 /**
  * Class RowIterator
  * Iterate over CSV rows.
  */
-class RowIterator implements IteratorInterface
+class RowIterator implements RowIteratorInterface
 {
     /**
      * Value passed to fgetcsv. 0 means "unlimited" (slightly slower but accomodates for very long lines).

--- a/src/Spout/Reader/CSV/SheetIterator.php
+++ b/src/Spout/Reader/CSV/SheetIterator.php
@@ -2,13 +2,13 @@
 
 namespace Box\Spout\Reader\CSV;
 
-use Box\Spout\Reader\IteratorInterface;
+use Box\Spout\Reader\SheetIteratorInterface;
 
 /**
  * Class SheetIterator
  * Iterate over CSV unique "sheet".
  */
-class SheetIterator implements IteratorInterface
+class SheetIterator implements SheetIteratorInterface
 {
     /** @var \Box\Spout\Reader\CSV\Sheet The CSV unique "sheet" */
     protected $sheet;

--- a/src/Spout/Reader/ReaderAbstract.php
+++ b/src/Spout/Reader/ReaderAbstract.php
@@ -7,6 +7,7 @@ use Box\Spout\Common\Helper\GlobalFunctionsHelper;
 use Box\Spout\Common\Manager\OptionsManagerInterface;
 use Box\Spout\Reader\Common\Creator\InternalEntityFactoryInterface;
 use Box\Spout\Reader\Common\Entity\Options;
+use Box\Spout\Reader\CSV\SheetIterator;
 use Box\Spout\Reader\Exception\ReaderNotOpenedException;
 
 /**
@@ -46,7 +47,7 @@ abstract class ReaderAbstract implements ReaderInterface
     /**
      * Returns an iterator to iterate over sheets.
      *
-     * @return IteratorInterface To iterate over sheets
+     * @return SheetIteratorInterface To iterate over sheets
      */
     abstract protected function getConcreteSheetIterator();
 
@@ -211,7 +212,7 @@ abstract class ReaderAbstract implements ReaderInterface
      * Returns an iterator to iterate over sheets.
      *
      * @throws \Box\Spout\Reader\Exception\ReaderNotOpenedException If called before opening the reader
-     * @return \Iterator To iterate over sheets
+     * @return SheetIteratorInterface To iterate over sheets
      */
     public function getSheetIterator()
     {

--- a/src/Spout/Reader/ReaderInterface.php
+++ b/src/Spout/Reader/ReaderInterface.php
@@ -21,7 +21,7 @@ interface ReaderInterface
      * Returns an iterator to iterate over sheets.
      *
      * @throws \Box\Spout\Reader\Exception\ReaderNotOpenedException If called before opening the reader
-     * @return \Iterator To iterate over sheets
+     * @return SheetIteratorInterface To iterate over sheets
      */
     public function getSheetIterator();
 

--- a/src/Spout/Reader/RowIteratorInterface.php
+++ b/src/Spout/Reader/RowIteratorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Box\Spout\Reader;
+
+use Box\Spout\Common\Entity\Row;
+
+interface RowIteratorInterface extends IteratorInterface
+{
+    /**
+     * Cleans up what was created to iterate over the object.
+     *
+     * @return void
+     */
+    public function end();
+
+    /**
+     * @return Row|null
+     */
+    public function current();
+}

--- a/src/Spout/Reader/SheetIteratorInterface.php
+++ b/src/Spout/Reader/SheetIteratorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Box\Spout\Reader;
+
+/**
+ * Interface IteratorInterface
+ */
+interface SheetIteratorInterface extends IteratorInterface
+{
+    /**
+     * Cleans up what was created to iterate over the object.
+     *
+     * @return void
+     */
+    public function end();
+
+    /**
+     * @return SheetInterface|null
+     */
+    public function current();
+}


### PR DESCRIPTION
Dedicated interfaces are needed for correct type-hinting.

When using PHP >= 7.4, a more strict interface would for example allow safe use of Row::toArray() when using the iterator.
If we keep the generic Iterator interface, the retruned item is `mixed` type and the use of `$item->toArray()` is not safe.