### PR TITLE
Update GlobalFunctionsHelper.php

### DIFF
--- a/src/Spout/Common/Helper/GlobalFunctionsHelper.php
+++ b/src/Spout/Common/Helper/GlobalFunctionsHelper.php
@@ -248,7 +248,7 @@ class GlobalFunctionsHelper
      */
     public function basename($path, $suffix = null)
     {
-        return \basename($path, $suffix);
+        return \basename($path, $suffix ?? '');
     }
 
     /**


### PR DESCRIPTION
PHP 8.1 issue. $suffix may not be null when using PHP's basename function. Default value is an empty string. Belongs to issue #844 