### PR TITLE
Enable est column width calculation

### DIFF
--- a/src/Spout/Writer/Common/Entity/Options.php
+++ b/src/Spout/Writer/Common/Entity/Options.php
@@ -16,6 +16,7 @@ abstract class Options
     // Multisheets options
     public const TEMP_FOLDER = 'tempFolder';
     public const DEFAULT_ROW_STYLE = 'defaultRowStyle';
+    public const ROWWIDTH_CALC_STYLE = 'rowCalcMethod';
     public const SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY = 'shouldCreateNewSheetsAutomatically';
 
     // XLSX specific options

--- a/src/Spout/Writer/Common/Entity/Worksheet.php
+++ b/src/Spout/Writer/Common/Entity/Worksheet.php
@@ -22,6 +22,21 @@ class Worksheet
 
     /** @var int Index of the last written row */
     private $lastWrittenRowIndex;
+    
+    /** @var array Array of the column widths */
+    protected $columnWidths;
+    
+    /** @var int Width calculation style */
+    protected $widthCalcuationStyle;
+    
+    /** @var int Fixed sheet width for fixed width calculation style */
+    protected $fixedSheetWidth;
+
+    public const W_FULL = 1;
+    public const W_FIXED = 2;
+    public const W_NONE = 0;
+    public const DEFAULT_COL_WIDTH = 30;
+    public const DEFAULT_FIXED_WIDTH = 1068;
 
     /**
      * Worksheet constructor.
@@ -36,6 +51,8 @@ class Worksheet
         $this->externalSheet = $externalSheet;
         $this->maxNumColumns = 0;
         $this->lastWrittenRowIndex = 0;
+        $this->columnWidths = [];
+        $this->widthCalcuationStyle = 0;
     }
 
     /**
@@ -79,11 +96,114 @@ class Worksheet
     }
 
     /**
+     * @return array
+     */
+    public function getColumnWidths()
+    {
+        return $this->columnWidths;
+    }
+
+    /**
+     * Gets the calculated max column width for the specified index
+     * @param int $zeroBasedIndex
+     * @return int
+     */
+    public function getMaxColumnWidth($zeroBasedIndex)
+    {
+        if (isset($this->columnWidths[$zeroBasedIndex])) {
+            return $this->columnWidths[$zeroBasedIndex];
+        }
+
+        $this->columnWidths[$zeroBasedIndex] = self::DEFAULT_COL_WIDTH;
+        return $this->columnWidths[$zeroBasedIndex];
+    }
+
+    /**
+     * Sets the calculated max column width for the specified index
+     * @param int $zeroBasedIndex
+     * @param int $value Value to set to
+     * @return void
+     */
+    public function setMaxColumnWidth($zeroBasedIndex, $value)
+    {
+        $curSize = $this->columnWidths[$zeroBasedIndex] ?? 0;
+        if ($curSize < $value) {
+            $this->columnWidths[$zeroBasedIndex] = $value;
+        }
+    }
+
+    /**
+     * Automatically calculates and sets the max column width for the specified cell
+     * @param Cell $cell The cell
+     * @param Style $style Row/Cell style
+     * @param int $zeroBasedIndex of cell
+     * @return void
+     */
+    public function autoSetWidth($cell, $style, $zeroBasedIndex)
+    {
+        $size = strlen($cell->getValue()) ?? 1;//use 1 as length if cell empty
+        $size *= (float)($style->getFontSize() ?? 10);
+        $size *= $style->isFontBold() ? 1.2 : 1.0;
+        if ($this->getWidthCalculation() == Worksheet::W_FIXED) {
+            $total = array_sum($this->getColumnWidths());
+            $total = $total ?: $size;
+            $size = ($size / $total) * $this->getFixedSheetWidth();
+        }
+        $size /= 10;
+        $this->setMaxColumnWidth($zeroBasedIndex, $size);
+    }
+
+    /**
+     * Gets the fixed sheet width or returns the default if not available
+     * @return int
+     */
+    public function getFixedSheetWidth()
+    {
+        if (!$this->fixedSheetWidth) {
+            return Worksheet::DEFAULT_FIXED_WIDTH;
+        }
+        return $this->fixedSheetWidth;
+    }
+
+    /**
+     * Sets the fixed sheet width
+     * @param int $width
+     * @return void
+     */
+    public function setFixedSheetWidth($width)
+    {
+        $this->fixedSheetWidth = $width;
+    }
+
+    /**
      * @param int $maxNumColumns
      */
     public function setMaxNumColumns($maxNumColumns)
     {
         $this->maxNumColumns = $maxNumColumns;
+    }
+
+    /**
+     * Set the with calculation style for this sheet.
+     * 1=FullExpand,2=FixedWidth,0=None
+     *
+     * @return Worksheet Enable method chaining for easy set width
+     */
+    public function setWidthCalculation($widthStyle)
+    {
+        $this->widthCalcuationStyle = $widthStyle;
+        return $this;
+    }
+
+    /**
+     * Get the with calculation style for this sheet.
+     * 1=FullExpand,2=FixedWidth,0=None
+     *
+     * @return void
+     */
+    public function getWidthCalculation()
+    {
+        return $this->widthCalcuationStyle;
     }
 
     /**

--- a/src/Spout/Writer/Common/Entity/Worksheet.php
+++ b/src/Spout/Writer/Common/Entity/Worksheet.php
@@ -141,15 +141,13 @@ class Worksheet
      */
     public function autoSetWidth($cell, $style, $zeroBasedIndex)
     {
-        $size = strlen($cell->getValue()) ?? 1;//use 1 as length if cell empty
-        $size *= (float)($style->getFontSize() ?? 10);
+        $size = 1 + strlen($cell->getValue());//ensure we have at least 1 space
         $size *= $style->isFontBold() ? 1.2 : 1.0;
         if ($this->getWidthCalculation() == Worksheet::W_FIXED) {
             $total = array_sum($this->getColumnWidths());
             $total = $total ?: $size;
             $size = ($size / $total) * $this->getFixedSheetWidth();
         }
-        $size /= 10;
         $this->setMaxColumnWidth($zeroBasedIndex, $size);
     }
 

--- a/src/Spout/Writer/Common/Helper/AppendHelper.php
+++ b/src/Spout/Writer/Common/Helper/AppendHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Box\Spout\Writer\Common\Helper;
+
+class AppendHelper {
+
+    /**
+     * Instead of seeking and re-writing from position, a better hack might be to write dummy empty data
+     * Enough to take care of any length, then carefully overwrite
+     * 
+     */
+
+    /**
+     * This function will truncate from specified position
+     * Write data to be inserted and re-append the truncated data
+     *  
+     * @param $fp Pointer to file only
+     * @param $pos Position to insert
+     * @param $content Content to insert
+     */
+    public static function insertToFile($fp, $pos, $content)
+    {
+        fseek($fp, $pos);
+        $trailer = stream_get_contents($fp);
+        ftruncate($fp, $pos);
+        fseek($fp, $pos);
+        fwrite($fp, $content);
+        fwrite($fp, $trailer);
+        return $fp;
+    }
+}

--- a/src/Spout/Writer/ODS/Creator/ManagerFactory.php
+++ b/src/Spout/Writer/ODS/Creator/ManagerFactory.php
@@ -48,7 +48,7 @@ class ManagerFactory implements ManagerFactoryInterface
 
         $styleMerger = $this->createStyleMerger();
         $styleManager = $this->createStyleManager($optionsManager);
-        $worksheetManager = $this->createWorksheetManager($styleManager, $styleMerger);
+        $worksheetManager = $this->createWorksheetManager($optionsManager, $styleManager, $styleMerger);
 
         return new WorkbookManager(
             $workbook,
@@ -63,16 +63,17 @@ class ManagerFactory implements ManagerFactoryInterface
     }
 
     /**
+     * @param OptionsManagerInterface $optionsManager
      * @param StyleManager $styleManager
      * @param StyleMerger $styleMerger
      * @return WorksheetManager
      */
-    private function createWorksheetManager(StyleManager $styleManager, StyleMerger $styleMerger)
+    private function createWorksheetManager(OptionsManagerInterface $optionsManager, StyleManager $styleManager, StyleMerger $styleMerger)
     {
         $stringsEscaper = $this->helperFactory->createStringsEscaper();
         $stringsHelper = $this->helperFactory->createStringHelper();
 
-        return new WorksheetManager($styleManager, $styleMerger, $stringsEscaper, $stringsHelper);
+        return new WorksheetManager($optionsManager, $styleManager, $styleMerger, $stringsEscaper, $stringsHelper);
     }
 
     /**

--- a/src/Spout/Writer/ODS/Helper/FileSystemHelper.php
+++ b/src/Spout/Writer/ODS/Helper/FileSystemHelper.php
@@ -202,7 +202,7 @@ EOD;
 EOD;
 
         $contentXmlFileContents .= $styleManager->getContentXmlFontFaceSectionContent();
-        $contentXmlFileContents .= $styleManager->getContentXmlAutomaticStylesSectionContent($worksheets);
+        $contentXmlFileContents .= $styleManager->getContentXmlAutomaticStylesSectionContent($worksheetManager, $worksheets);
 
         $contentXmlFileContents .= '<office:body><office:spreadsheet>';
 

--- a/src/Spout/Writer/ODS/Manager/OptionsManager.php
+++ b/src/Spout/Writer/ODS/Manager/OptionsManager.php
@@ -33,6 +33,7 @@ class OptionsManager extends OptionsManagerAbstract
         return [
             Options::TEMP_FOLDER,
             Options::DEFAULT_ROW_STYLE,
+            Options::ROWWIDTH_CALC_STYLE,
             Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY,
         ];
     }
@@ -45,5 +46,6 @@ class OptionsManager extends OptionsManagerAbstract
         $this->setOption(Options::TEMP_FOLDER, \sys_get_temp_dir());
         $this->setOption(Options::DEFAULT_ROW_STYLE, $this->styleBuilder->build());
         $this->setOption(Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY, true);
+        $this->setOption(Options::ROWWIDTH_CALC_STYLE, 0);
     }
 }

--- a/src/Spout/Writer/ODS/Manager/Style/StyleManager.php
+++ b/src/Spout/Writer/ODS/Manager/Style/StyleManager.php
@@ -151,17 +151,21 @@ EOD;
     /**
      * Returns the contents of the "<office:automatic-styles>" section, inside "content.xml" file.
      *
+     * @param WorksheetManager $manager
      * @param Worksheet[] $worksheets
      * @return string
      */
-    public function getContentXmlAutomaticStylesSectionContent($worksheets)
+    public function getContentXmlAutomaticStylesSectionContent($manager, $worksheets)
     {
         $content = '<office:automatic-styles>';
+
+        $content .= $manager->getWidthStylesContent($worksheets[0]);
 
         foreach ($this->styleRegistry->getRegisteredStyles() as $style) {
             $content .= $this->getStyleSectionContent($style);
         }
 
+        
         $content .= <<<'EOD'
 <style:style style:family="table-column" style:name="co1">
     <style:table-column-properties fo:break-before="auto"/>

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -9,6 +9,9 @@ use Box\Spout\Common\Exception\InvalidArgumentException;
 use Box\Spout\Common\Exception\IOException;
 use Box\Spout\Common\Helper\Escaper\ODS as ODSEscaper;
 use Box\Spout\Common\Helper\StringHelper;
+use Box\Spout\Common\Manager\OptionsManagerInterface;
+use Box\Spout\Writer\Common\Helper\AppendHelper;
+use Box\Spout\Writer\Common\Entity\Options;
 use Box\Spout\Writer\Common\Entity\Worksheet;
 use Box\Spout\Writer\Common\Manager\RegisteredStyle;
 use Box\Spout\Writer\Common\Manager\Style\StyleMerger;
@@ -33,20 +36,29 @@ class WorksheetManager implements WorksheetManagerInterface
     /** @var StyleMerger Helper to merge styles together */
     private $styleMerger;
 
+    /** $int file pointer head position */
+    private $headWritePosition;
+
+    /** @var int Width calculation style */
+    protected $widthCalcuationStyle;
+
     /**
      * WorksheetManager constructor.
      *
+     * @param OptionsManagerInterface $optionsManager
      * @param StyleManager $styleManager
      * @param StyleMerger $styleMerger
      * @param ODSEscaper $stringsEscaper
      * @param StringHelper $stringHelper
      */
     public function __construct(
+        OptionsManagerInterface $optionsManager,
         StyleManager $styleManager,
         StyleMerger $styleMerger,
         ODSEscaper $stringsEscaper,
         StringHelper $stringHelper
     ) {
+        $this->widthCalcuationStyle = $optionsManager->getOption(Options::ROWWIDTH_CALC_STYLE);
         $this->styleManager = $styleManager;
         $this->styleMerger = $styleMerger;
         $this->stringsEscaper = $stringsEscaper;
@@ -62,8 +74,13 @@ class WorksheetManager implements WorksheetManagerInterface
      */
     public function startSheet(Worksheet $worksheet)
     {
-        $sheetFilePointer = \fopen($worksheet->getFilePath(), 'w');
+        $sheetFilePointer = \fopen($worksheet->getFilePath(), 'w+');
         $this->throwIfSheetFilePointerIsNotAvailable($sheetFilePointer);
+
+        $worksheet->setWidthCalculation($this->widthCalcuationStyle);
+        if ($worksheet->getWidthCalculation() != Worksheet::W_NONE) {
+            $this->headWritePosition = ftell($sheetFilePointer);
+        }
 
         $worksheet->setFilePointer($sheetFilePointer);
     }
@@ -95,7 +112,15 @@ class WorksheetManager implements WorksheetManagerInterface
         $tableStyleName = 'ta' . ($externalSheet->getIndex() + 1);
 
         $tableElement = '<table:table table:style-name="' . $tableStyleName . '" table:name="' . $escapedSheetName . '">';
-        $tableElement .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="co1" table:number-columns-repeated="' . $worksheet->getMaxNumColumns() . '"/>';
+
+        if ($worksheet->getWidthCalculation() != Worksheet::W_NONE) {
+            foreach ($worksheet->getColumnWidths() as $i => $w){
+                $colNo = $i + 1;
+                $tableElement .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="co'.$colNo.'"/>';
+            }
+        } else {
+            $tableElement .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="co1" table:number-columns-repeated="' . $worksheet->getMaxNumColumns() . '"/>';
+        }
 
         return $tableElement;
     }
@@ -124,6 +149,10 @@ class WorksheetManager implements WorksheetManagerInterface
             $cell = $cells[$currentCellIndex];
             /** @var Cell|null $nextCell */
             $nextCell = isset($cells[$nextCellIndex]) ? $cells[$nextCellIndex] : null;
+
+            if ($worksheet->getWidthCalculation() != Worksheet::W_NONE) {
+                $worksheet->autoSetWidth($cell, $rowStyle, $i);
+            }
 
             if ($nextCell === null || $cell->getValue() !== $nextCell->getValue()) {
                 $registeredStyle = $this->applyStyleAndRegister($cell, $rowStyle);
@@ -247,6 +276,26 @@ class WorksheetManager implements WorksheetManagerInterface
         }
 
         return $data;
+    }
+
+    public function getWidthStylesContent($worksheet)
+    {
+        if ($worksheet->getWidthCalculation() != Worksheet::W_NONE) {            
+            //create the col styles
+            $style = '';
+            $widths = $worksheet->getColumnWidths();
+            //todo: this may not be adequate for multiple worksheets
+            foreach ($widths as $i => $width){
+                $win = round($width / 9.6, 2);//convert to inches
+                $colNo = $i + 1;
+                $style .= '<style:style style:name="co'.$colNo.
+                '" style:family="table-column"><style:table-column-properties fo:break-before="auto" style:column-width="'.
+                $win.
+                'in"/></style:style>';
+            }
+            return $style;
+        }
+        return "";
     }
 
     /**

--- a/src/Spout/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Spout/Writer/ODS/Manager/WorksheetManager.php
@@ -286,6 +286,7 @@ class WorksheetManager implements WorksheetManagerInterface
             $widths = $worksheet->getColumnWidths();
             //todo: this may not be adequate for multiple worksheets
             foreach ($widths as $i => $width){
+                //this is a rough equivalent based on pixel density
                 $win = round($width / 9.6, 2);//convert to inches
                 $colNo = $i + 1;
                 $style .= '<style:style style:name="co'.$colNo.

--- a/src/Spout/Writer/WriterMultiSheetsAbstract.php
+++ b/src/Spout/Writer/WriterMultiSheetsAbstract.php
@@ -26,6 +26,9 @@ abstract class WriterMultiSheetsAbstract extends WriterAbstract
 
     /** @var WorkbookManagerInterface|null */
     private $workbookManager;
+        
+    /** @var int Width calculation style */
+    protected $widthCalcuationStyle;
 
     /**
      * @param OptionsManagerInterface $optionsManager
@@ -144,6 +147,22 @@ abstract class WriterMultiSheetsAbstract extends WriterAbstract
         if ($this->workbookManager->getWorkbook() === null) {
             throw new WriterNotOpenedException('The writer must be opened before performing this action.');
         }
+    }
+
+    /**
+     * Set default sheet width calculation option
+     *
+     * @param int $option The width calculation style
+     * @throws \Box\Spout\Writer\Exception\WriterAlreadyOpenedException If the writer was already opened
+     * @return Writer
+     */
+    public function setWidthCalculation($option)
+    {
+        $this->throwIfWriterAlreadyOpened('Writer must be configured before opening it.');
+
+        $this->optionsManager->setOption(Options::ROWWIDTH_CALC_STYLE, $option);
+
+        return $this;
     }
 
     /**

--- a/src/Spout/Writer/XLSX/Manager/OptionsManager.php
+++ b/src/Spout/Writer/XLSX/Manager/OptionsManager.php
@@ -37,6 +37,7 @@ class OptionsManager extends OptionsManagerAbstract
         return [
             Options::TEMP_FOLDER,
             Options::DEFAULT_ROW_STYLE,
+            Options::ROWWIDTH_CALC_STYLE,
             Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY,
             Options::SHOULD_USE_INLINE_STRINGS,
         ];
@@ -56,5 +57,6 @@ class OptionsManager extends OptionsManagerAbstract
         $this->setOption(Options::DEFAULT_ROW_STYLE, $defaultRowStyle);
         $this->setOption(Options::SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY, true);
         $this->setOption(Options::SHOULD_USE_INLINE_STRINGS, true);
+        $this->setOption(Options::ROWWIDTH_CALC_STYLE, 0);
     }
 }


### PR DESCRIPTION
This is a first step to resolving https://github.com/box/spout/issues/129

This approach primarily computes the width size by using an estimate created

After the PR, the library may be used as follows (sample outputs are attached below):

```
<?php

use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
use Box\Spout\Common\Type;

require __DIR__ . '/vendor/autoload.php';

function generateRows()
{
    $data = [];
    $headers = [];
    for($i=0;$i<10;$i++) {
        $headers[] = "COL-".generateRandomString(5);
    }
    
    $data = [
        $headers
    ];
    
    for($i=0; $i< 10; $i++) {
        $row = [];
        $rand = mt_rand(1, 30);
        foreach ($headers as $header) {
            $randLen = mt_rand(1, $rand);
            $row[] = generateRandomString($randLen);
        }
        $data[] = $row;
    }
    return $data;
}

function generateRandomString($length = 10) {
    $characters = 'aaaaeeeeiiiiiiiioooouuuubcdefghijklmnopqrstuvwxyz';
    $charactersLength = strlen($characters);
    $randomString = '';
    for ($i = 0; $i < $length; $i++) {
        $randomString .= $characters[rand(0, $charactersLength - 1)];
    }
    return $randomString;
}

$data = generateRows();

$writer = WriterEntityFactory::createWriter(Type::ODS);
$writer->setWidthCalculation(1);
$writer->openToFile('spouter.ods');

foreach ($data as $row) {
    $writer->addRow(WriterEntityFactory::createRowFromArray($row));
}

$writer->close();
[spouter.xlsx](https://github.com/box/spout/files/8006663/spouter.xlsx)
[spouter.ods](https://github.com/box/spout/files/8006665/spouter.ods)


?>
```