### PR TITLE
Use DateTimeInterface

### DIFF
--- a/src/Spout/Common/Helper/CellTypeHelper.php
+++ b/src/Spout/Common/Helper/CellTypeHelper.php
@@ -61,7 +61,7 @@ class CellTypeHelper
     public static function isDateTimeOrDateInterval($value)
     {
         return (
-            $value instanceof \DateTime ||
+            $value instanceof \DateTimeInterface ||
             $value instanceof \DateInterval
         );
     }


### PR DESCRIPTION
Check if field is a `DateTimeInterface` instead of `DateTime`, so you can pass a `DateTimeImmutable` object or some extension of `DateTime` like `Carbon`. 