### PR TITLE
allows to pass formats as array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=8.0",
         "ext-zip": "*",
         "ext-xmlreader": "*",
         "ext-dom": "*"

--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -7,6 +7,7 @@ use Box\Spout\Common\Entity\Row;
 use Box\Spout\Common\Entity\Style\Style;
 use Box\Spout\Common\Exception\UnsupportedTypeException;
 use Box\Spout\Common\Type;
+use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
 use Box\Spout\Writer\WriterInterface;
 
 /**
@@ -101,9 +102,12 @@ class WriterEntityFactory
      */
     public static function createRowFromArray(array $cellValues = [], Style $rowStyle = null)
     {
-        $cells = \array_map(function ($cellValue) {
-            return new Cell($cellValue);
-        }, $cellValues);
+        $format = $rowStyle?->getFormat();
+
+        $cells = \array_map(function ($k, $cellValue) {
+            $cellStyle = (new StyleBuilder())->setFormat($format[$k] ?? '@')->build();
+            return new Cell($cellValue, $cellStyle);
+        }, array_keys($cellValues), $cellValues);
 
         return new Row($cells, $rowStyle);
     }

--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -103,10 +103,15 @@ class WriterEntityFactory
     public static function createRowFromArray(array $cellValues = [], Style $rowStyle = null)
     {
         $format = $rowStyle?->getFormat();
+        $cellStyles = [];
 
-        $cells = \array_map(function ($k, $cellValue) {
-            $cellStyle = (new StyleBuilder())->setFormat($format[$k] ?? '@')->build();
-            return new Cell($cellValue, $cellStyle);
+        if (is_array($format)) {
+            foreach ($format as $k => $f)
+                $cellStyles[$k] = (new StyleBuilder())->setFormat($f ?? '@')->build();
+        }
+
+        $cells = \array_map(function ($k, $cellValue) use ($cellStyles) {
+            return new Cell($cellValue, $cellStyles[$k] ?? null);
         }, array_keys($cellValues), $cellValues);
 
         return new Row($cells, $rowStyle);

--- a/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
+++ b/src/Spout/Writer/Common/Creator/WriterEntityFactory.php
@@ -112,7 +112,7 @@ class WriterEntityFactory
 
         $cells = \array_map(function ($k, $cellValue) use ($cellStyles) {
             return new Cell($cellValue, $cellStyles[$k] ?? null);
-        }, array_keys($cellValues), $cellValues);
+        }, array_keys(array_values($cellValues)), $cellValues);
 
         return new Row($cells, $rowStyle);
     }

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleRegistry.php
@@ -141,7 +141,7 @@ class StyleRegistry extends \Box\Spout\Writer\Common\Manager\Style\StyleRegistry
         $styleId = $style->getId();
 
         $format = $style->getFormat();
-        if ($format) {
+        if (!is_array($format)) {
             $isFormatRegistered = isset($this->registeredFormats[$format]);
 
             // We need to track the already registered format definitions


### PR DESCRIPTION
Allows to pass format as array like this:

```
$style = (new StyleBuilder())
           ->setFontBold()
           ->setFontSize(15)
           ->setFormat(['@', '0.000', '0.0000', '0.00%'])
           ->build();
```

or as string as before.
Each format will apply to subsequent columns, if there is more columns than formats, `text` format will apply

also php >= 8.0 are required because of null safe operator